### PR TITLE
Add social sidebar section with animated feed updates

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -191,6 +191,96 @@
     gap: 8px;
 }
 
+.library-header-title-wrap {
+    position: relative;
+    min-width: 0;
+}
+
+.sidebar-section-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    transition: opacity 140ms ease;
+}
+
+.sidebar-section-trigger:hover {
+    opacity: 1;
+}
+
+.sidebar-section-trigger:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.18);
+    outline-offset: 4px;
+    border-radius: 6px;
+}
+
+.sidebar-section-trigger-arrow {
+    width: 0.78rem;
+    height: 0.78rem;
+    display: block;
+    opacity: 0.8;
+    transition: transform 140ms ease;
+}
+
+.sidebar-section-trigger[aria-expanded='true'] .sidebar-section-trigger-arrow {
+    transform: translateY(1px) rotate(180deg);
+}
+
+.sidebar-section-menu {
+    position: absolute;
+    left: 0;
+    top: calc(100% + 0.45rem);
+    z-index: 20;
+    min-width: 9rem;
+    padding: 0.3rem;
+    border-radius: 0.7rem;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(18, 18, 20, 0.98);
+    backdrop-filter: blur(14px);
+    box-shadow: 0 10px 32px rgba(0, 0, 0, 0.45);
+}
+
+.sidebar-section-menu[hidden] {
+    display: none;
+}
+
+.sidebar-section-menu-item {
+    display: block;
+    width: 100%;
+    border: none;
+    border-radius: 0.5rem;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-align: left;
+    white-space: nowrap;
+    padding: 0.46rem 0.58rem;
+    cursor: pointer;
+    transition: background 130ms ease;
+}
+
+.sidebar-section-menu-item:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.sidebar-section-menu-item.is-active {
+    background: rgba(255, 255, 255, 0.16);
+}
+
 .library-scan-yield-indicator {
     display: inline-flex;
     align-items: center;
@@ -218,6 +308,31 @@
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
+}
+
+.sidebar-pane {
+    min-height: 0;
+    flex: 1;
+}
+
+.sidebar-pane.is-section-entering {
+    animation: sidebar-pane-section-enter 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.sidebar-pane[hidden] {
+    display: none;
+}
+
+.sidebar-pane-library {
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar-pane-social {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    padding-top: 1rem;
 }
 
 #library-upload {
@@ -342,6 +457,212 @@
     position: relative;
     flex: 1;
     overflow: hidden;
+}
+
+.social-feed-status {
+    margin: 0 0 0.8rem;
+    font-size: 0.77rem;
+    line-height: 1.3;
+    color: rgba(255, 255, 255, 0.68);
+}
+
+.social-feed-status:empty {
+    display: none;
+}
+
+.social-feed-list {
+    flex: 1;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding-right: 0.2rem;
+}
+
+.social-feed-list.is-animating .social-feed-card,
+.social-feed-list.is-animating .social-feed-empty {
+    animation: social-feed-card-update 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.social-feed-card {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
+    border-radius: 16px;
+    padding: 0.9rem 0.95rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.social-feed-card.is-live {
+    border-color: rgba(116, 214, 170, 0.32);
+    background: linear-gradient(160deg, rgba(116, 214, 170, 0.12), rgba(255, 255, 255, 0.04));
+}
+
+.social-feed-card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.8rem;
+}
+
+.social-feed-identity {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    min-width: 0;
+}
+
+.social-feed-avatar {
+    width: 1.05rem;
+    height: 1.2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+}
+
+.social-feed-listenbrainz-icon {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.social-feed-user-copy {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    min-width: 0;
+    text-align: left;
+}
+
+.social-feed-user,
+.social-feed-verb,
+.social-feed-track,
+.social-feed-meta {
+    margin: 0;
+}
+
+.social-feed-user {
+    font-size: 0.84rem;
+    font-weight: 700;
+    line-height: 1.2;
+    color: rgba(255, 255, 255, 0.96);
+    text-align: left;
+}
+
+.social-feed-verb {
+    margin-top: 0.12rem;
+    font-size: 0.73rem;
+    line-height: 1.25;
+    color: rgba(255, 255, 255, 0.62);
+    letter-spacing: 0.03em;
+    text-align: left;
+}
+
+.social-feed-time {
+    flex: 0 0 auto;
+    font-size: 0.74rem;
+    line-height: 1.2;
+    color: rgba(255, 255, 255, 0.62);
+    text-align: right;
+}
+
+.social-feed-track {
+    margin-top: 1rem;
+    font-size: 0.98rem;
+    font-weight: 700;
+    line-height: 1.3;
+    color: rgba(255, 255, 255, 0.96);
+}
+
+.social-feed-meta {
+    margin-top: 0.2rem;
+    font-size: 0.82rem;
+    line-height: 1.35;
+    color: rgba(255, 255, 255, 0.72);
+}
+
+.social-feed-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.7rem;
+}
+
+.social-feed-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    padding: 0.22rem 0.5rem;
+    font-size: 0.7rem;
+    line-height: 1;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.86);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.social-feed-badge.is-live {
+    color: rgba(180, 255, 220, 0.96);
+    border-color: rgba(116, 214, 170, 0.28);
+    background: rgba(116, 214, 170, 0.12);
+}
+
+.social-feed-empty {
+    border: 1px dashed rgba(255, 255, 255, 0.14);
+    border-radius: 16px;
+    padding: 1rem;
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.social-feed-empty-title,
+.social-feed-empty-detail {
+    margin: 0;
+}
+
+.social-feed-empty-title {
+    font-size: 0.88rem;
+    font-weight: 700;
+    line-height: 1.35;
+}
+
+.social-feed-empty-detail {
+    margin-top: 0.35rem;
+    font-size: 0.8rem;
+    line-height: 1.45;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+@keyframes social-feed-card-update {
+    0% {
+        opacity: 0;
+        transform: translateY(10px) scale(0.985);
+        filter: saturate(0.9);
+    }
+
+    55% {
+        opacity: 1;
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+        filter: saturate(1);
+    }
+}
+
+@keyframes sidebar-pane-section-enter {
+    0% {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .library-viewport-loading-indicator {

--- a/frontend/src/components/sidebar.ts
+++ b/frontend/src/components/sidebar.ts
@@ -1,52 +1,82 @@
 export type SidebarElements = {
     sidebarToggle: HTMLButtonElement;
     librarySidebar: HTMLElement;
-  libraryScanYieldIndicator: HTMLSpanElement;
+    libraryScanYieldIndicator: HTMLSpanElement;
     librarySettings: HTMLButtonElement;
     libraryAbout: HTMLButtonElement;
+  sidebarSectionTrigger: HTMLButtonElement;
+  sidebarSectionTriggerLabel: HTMLSpanElement;
+  sidebarSectionMenu: HTMLDivElement;
+  sidebarSectionOptionLibrary: HTMLButtonElement;
+  sidebarSectionOptionSocial: HTMLButtonElement;
+    sidebarPaneLibrary: HTMLElement;
+    sidebarPaneSocial: HTMLElement;
     libraryBack: HTMLButtonElement;
     libraryPath: HTMLParagraphElement;
     librarySearch: HTMLInputElement;
     libraryBrowser: HTMLDivElement;
+    socialFeedStatus: HTMLParagraphElement;
+    socialFeedList: HTMLDivElement;
 };
 
 export const renderSidebar = (): string => `
-    <button id="sidebar-toggle" class="sidebar-toggle" type="button" aria-label="Open library"><svg class="sidebar-toggle-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M4 6.5C4 5.67 4.67 5 5.5 5H18.5C19.33 5 20 5.67 20 6.5C20 7.33 19.33 8 18.5 8H5.5C4.67 8 4 7.33 4 6.5ZM4 12C4 11.17 4.67 10.5 5.5 10.5H18.5C19.33 10.5 20 11.17 20 12C20 12.83 19.33 13.5 18.5 13.5H5.5C4.67 13.5 4 12.83 4 12ZM4 17.5C4 16.67 4.67 16 5.5 16H18.5C19.33 16 20 16.67 20 17.5C20 18.33 19.33 19 18.5 19H5.5C4.67 19 4 18.33 4 17.5Z"/></svg></button>
+    <button id="sidebar-toggle" class="sidebar-toggle" type="button" aria-label="Open sidebar"><svg class="sidebar-toggle-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M4 6.5C4 5.67 4.67 5 5.5 5H18.5C19.33 5 20 5.67 20 6.5C20 7.33 19.33 8 18.5 8H5.5C4.67 8 4 7.33 4 6.5ZM4 12C4 11.17 4.67 10.5 5.5 10.5H18.5C19.33 10.5 20 11.17 20 12C20 12.83 19.33 13.5 18.5 13.5H5.5C4.67 13.5 4 12.83 4 12ZM4 17.5C4 16.67 4.67 16 5.5 16H18.5C19.33 16 20 16.67 20 17.5C20 18.33 19.33 19 18.5 19H5.5C4.67 19 4 18.33 4 17.5Z"/></svg></button>
     <button id="library-about" class="about-toggle" type="button" aria-label="About" title="About">i</button>
     <aside id="library-sidebar" class="library-sidebar" aria-hidden="true">
       <div class="library-header">
-        <h2 class="library-header-title">Library <span id="library-scan-yield-indicator" class="library-scan-yield-indicator" role="img" aria-label="Performance will be degraded until the library scan completes." title="Performance will be degraded until the library scan completes."><svg class="library-scan-yield-icon" width="12" height="12" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M11.12 3.86C11.51 3.18 12.49 3.18 12.88 3.86L21.02 18.14C21.4 18.81 20.92 19.65 20.15 19.65H3.85C3.08 19.65 2.6 18.81 2.98 18.14L11.12 3.86Z"/><rect x="11" y="8" width="2" height="7" rx="1" fill="#101010"/><circle cx="12" cy="17.5" r="1.35" fill="#101010"/></svg></span></h2>
+        <div class="library-header-title-wrap">
+          <h2 class="library-header-title"><button id="sidebar-section-trigger" class="sidebar-section-trigger" type="button" aria-haspopup="menu" aria-expanded="false" aria-controls="sidebar-section-menu"><span id="sidebar-section-trigger-label">LIBRARY</span><svg class="sidebar-section-trigger-arrow" width="12" height="12" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M7.41 9.59C7.79 9.21 8.4 9.21 8.78 9.59L12 12.81L15.22 9.59C15.6 9.21 16.21 9.21 16.59 9.59C16.97 9.97 16.97 10.58 16.59 10.96L12.69 14.86C12.31 15.24 11.69 15.24 11.31 14.86L7.41 10.96C7.03 10.58 7.03 9.97 7.41 9.59Z"/></svg></button><span id="library-scan-yield-indicator" class="library-scan-yield-indicator" role="img" aria-label="Performance will be degraded until the library scan completes." title="Performance will be degraded until the library scan completes."><svg class="library-scan-yield-icon" width="12" height="12" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M11.12 3.86C11.51 3.18 12.49 3.18 12.88 3.86L21.02 18.14C21.4 18.81 20.92 19.65 20.15 19.65H3.85C3.08 19.65 2.6 18.81 2.98 18.14L11.12 3.86Z"/><rect x="11" y="8" width="2" height="7" rx="1" fill="#101010"/><circle cx="12" cy="17.5" r="1.35" fill="#101010"/></svg></span></h2>
+          <div id="sidebar-section-menu" class="sidebar-section-menu" role="menu" aria-label="Sidebar sections" hidden>
+            <button id="sidebar-section-option-library" class="sidebar-section-menu-item is-active" type="button" role="menuitemradio" aria-checked="true">LIBRARY</button>
+            <button id="sidebar-section-option-social" class="sidebar-section-menu-item" type="button" role="menuitemradio" aria-checked="false">SOCIAL</button>
+          </div>
+        </div>
         <div class="library-header-actions">
           <button id="library-settings" class="upload-btn" type="button" aria-label="Settings" title="Settings"><svg class="library-settings-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M10.76 2.74C11.44 1.75 12.56 1.75 13.24 2.74L14.11 4.02C14.39 4.43 14.9 4.59 15.37 4.42L16.85 3.89C17.99 3.48 18.87 4.13 18.94 5.32L19.03 6.85C19.06 7.34 19.4 7.76 19.88 7.89L21.35 8.29C22.49 8.6 22.84 9.66 22.12 10.61L21.2 11.8C20.9 12.18 20.9 12.72 21.2 13.1L22.12 14.39C22.84 15.34 22.49 16.4 21.35 16.71L19.88 17.11C19.4 17.24 19.06 17.66 19.03 18.15L18.94 19.68C18.87 20.87 17.99 21.52 16.85 21.11L15.37 20.58C14.9 20.41 14.39 20.57 14.11 20.98L13.24 22.26C12.56 23.25 11.44 23.25 10.76 22.26L9.89 20.98C9.61 20.57 9.1 20.41 8.63 20.58L7.15 21.11C6.01 21.52 5.13 20.87 5.06 19.68L4.97 18.15C4.94 17.66 4.6 17.24 4.12 17.11L2.65 16.71C1.51 16.4 1.16 15.34 1.88 14.39L2.8 13.1C3.1 12.72 3.1 12.18 2.8 11.8L1.88 10.61C1.16 9.66 1.51 8.6 2.65 8.29L4.12 7.89C4.6 7.76 4.94 7.34 4.97 6.85L5.06 5.32C5.13 4.13 6.01 3.48 7.15 3.89L8.63 4.42C9.1 4.59 9.61 4.43 9.89 4.02L10.76 2.74ZM12 8.25C9.93 8.25 8.25 9.93 8.25 12C8.25 14.07 9.93 15.75 12 15.75C14.07 15.75 15.75 14.07 15.75 12C15.75 9.93 14.07 8.25 12 8.25Z"/></svg></button>
         </div>
       </div>
-      <div class="library-toolbar">
-        <button id="library-back" class="library-back" type="button" aria-label="Go to parent folder"><svg class="library-back-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M14.53 5.47C15.12 6.06 15.12 7.01 14.53 7.6L10.12 12L14.53 16.4C15.12 16.99 15.12 17.94 14.53 18.53C13.94 19.12 12.99 19.12 12.4 18.53L6.94 13.06C6.35 12.47 6.35 11.53 6.94 10.94L12.4 5.47C12.99 4.88 13.94 4.88 14.53 5.47Z"/></svg></button>
-        <p id="library-path" class="library-path">No folder selected</p>
-      </div>
-      <div class="library-search-row">
-        <input
-          id="library-search"
-          class="library-search"
-          type="search"
-          placeholder="Search files in library"
-          aria-label="Search files in library"
-          autocomplete="off"
-          spellcheck="false"
-        >
-      </div>
-      <div id="library-browser" class="library-browser"></div>
+      <section id="sidebar-pane-library" class="sidebar-pane sidebar-pane-library">
+        <div class="library-toolbar">
+          <button id="library-back" class="library-back" type="button" aria-label="Go to parent folder"><svg class="library-back-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M14.53 5.47C15.12 6.06 15.12 7.01 14.53 7.6L10.12 12L14.53 16.4C15.12 16.99 15.12 17.94 14.53 18.53C13.94 19.12 12.99 19.12 12.4 18.53L6.94 13.06C6.35 12.47 6.35 11.53 6.94 10.94L12.4 5.47C12.99 4.88 13.94 4.88 14.53 5.47Z"/></svg></button>
+          <p id="library-path" class="library-path">No folder selected</p>
+        </div>
+        <div class="library-search-row">
+          <input
+            id="library-search"
+            class="library-search"
+            type="search"
+            placeholder="Search files in library"
+            aria-label="Search files in library"
+            autocomplete="off"
+            spellcheck="false"
+          >
+        </div>
+        <div id="library-browser" class="library-browser"></div>
+      </section>
+      <section id="sidebar-pane-social" class="sidebar-pane sidebar-pane-social" hidden>
+        <p id="social-feed-status" class="social-feed-status" aria-live="polite"></p>
+        <div id="social-feed-list" class="social-feed-list"></div>
+      </section>
     </aside>
 `;
 
 export const getSidebarElements = (root: ParentNode): SidebarElements => ({
     sidebarToggle: root.querySelector('#sidebar-toggle') as HTMLButtonElement,
     librarySidebar: root.querySelector('#library-sidebar') as HTMLElement,
-  libraryScanYieldIndicator: root.querySelector('#library-scan-yield-indicator') as HTMLSpanElement,
+    libraryScanYieldIndicator: root.querySelector('#library-scan-yield-indicator') as HTMLSpanElement,
     librarySettings: root.querySelector('#library-settings') as HTMLButtonElement,
     libraryAbout: root.querySelector('#library-about') as HTMLButtonElement,
+    sidebarSectionTrigger: root.querySelector('#sidebar-section-trigger') as HTMLButtonElement,
+    sidebarSectionTriggerLabel: root.querySelector('#sidebar-section-trigger-label') as HTMLSpanElement,
+    sidebarSectionMenu: root.querySelector('#sidebar-section-menu') as HTMLDivElement,
+    sidebarSectionOptionLibrary: root.querySelector('#sidebar-section-option-library') as HTMLButtonElement,
+    sidebarSectionOptionSocial: root.querySelector('#sidebar-section-option-social') as HTMLButtonElement,
+    sidebarPaneLibrary: root.querySelector('#sidebar-pane-library') as HTMLElement,
+    sidebarPaneSocial: root.querySelector('#sidebar-pane-social') as HTMLElement,
     libraryBack: root.querySelector('#library-back') as HTMLButtonElement,
     libraryPath: root.querySelector('#library-path') as HTMLParagraphElement,
     librarySearch: root.querySelector('#library-search') as HTMLInputElement,
     libraryBrowser: root.querySelector('#library-browser') as HTMLDivElement,
+    socialFeedStatus: root.querySelector('#social-feed-status') as HTMLParagraphElement,
+    socialFeedList: root.querySelector('#social-feed-list') as HTMLDivElement,
 });

--- a/frontend/src/controllers/library-controller.ts
+++ b/frontend/src/controllers/library-controller.ts
@@ -264,7 +264,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
         }
 
         sidebarToggle.setAttribute('aria-busy', 'false');
-        sidebarToggle.setAttribute('aria-label', sidebarOpen ? 'Close library' : 'Open library');
+        sidebarToggle.setAttribute('aria-label', sidebarOpen ? 'Close sidebar' : 'Open sidebar');
     };
 
     const setLibraryLoading = (loading: boolean): void => {

--- a/frontend/src/controllers/listenbrainz-social-controller.test.ts
+++ b/frontend/src/controllers/listenbrainz-social-controller.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ListenBrainzSocialEvent } from '../types/app-types';
+import { createListenBrainzSocialController } from './listenbrainz-social-controller';
+
+const createEvent = (overrides: Partial<ListenBrainzSocialEvent> = {}): ListenBrainzSocialEvent => ({
+    id: 1,
+    created: 1710000100,
+    eventType: 'listen',
+    hidden: false,
+    userName: 'alice',
+    listenedAt: 1710000000,
+    listenedAtIso: '2024-03-09T16:00:00Z',
+    playingNow: false,
+    trackMetadata: {
+        artistName: 'Artist One',
+        trackName: 'Track One',
+        releaseName: 'Album One',
+        additionalInfo: {
+            musicServiceName: 'Spotify',
+        },
+    },
+    ...overrides,
+});
+
+const flushPromises = async (): Promise<void> => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
+const mountController = (options?: {
+    token?: string;
+    isSidebarVisible?: () => boolean;
+    fetchFollowingUsers?: () => Promise<string[]>;
+    fetchFollowingFeed?: (count: number) => Promise<ListenBrainzSocialEvent[]>;
+}) => {
+    document.body.innerHTML = `
+        <button id="sidebar-toggle" type="button"></button>
+        <button id="sidebar-section-trigger" type="button"><span id="sidebar-section-trigger-label"></span></button>
+        <div id="sidebar-section-menu" hidden>
+            <button id="sidebar-section-option-library" type="button"></button>
+            <button id="sidebar-section-option-social" type="button"></button>
+        </div>
+        <section id="sidebar-pane-library"></section>
+        <section id="sidebar-pane-social" hidden></section>
+        <p id="social-feed-status"></p>
+        <div id="social-feed-list"></div>
+    `;
+
+    const sidebarToggle = document.querySelector('#sidebar-toggle') as HTMLButtonElement;
+    const sidebarSectionTrigger = document.querySelector('#sidebar-section-trigger') as HTMLButtonElement;
+    const sidebarSectionTriggerLabel = document.querySelector('#sidebar-section-trigger-label') as HTMLSpanElement;
+    const sidebarSectionMenu = document.querySelector('#sidebar-section-menu') as HTMLDivElement;
+    const sidebarSectionOptionLibrary = document.querySelector('#sidebar-section-option-library') as HTMLButtonElement;
+    const sidebarSectionOptionSocial = document.querySelector('#sidebar-section-option-social') as HTMLButtonElement;
+    const sidebarPaneLibrary = document.querySelector('#sidebar-pane-library') as HTMLElement;
+    const sidebarPaneSocial = document.querySelector('#sidebar-pane-social') as HTMLElement;
+    const socialFeedStatus = document.querySelector('#social-feed-status') as HTMLParagraphElement;
+    const socialFeedList = document.querySelector('#social-feed-list') as HTMLDivElement;
+
+    const fetchFollowingUsers = options?.fetchFollowingUsers || vi.fn(async () => ['alice', 'bob']);
+    const fetchFollowingFeed = options?.fetchFollowingFeed || vi.fn(async () => [createEvent()]);
+
+    const controller = createListenBrainzSocialController({
+        elements: {
+            sidebarToggle,
+            sidebarSectionTrigger,
+            sidebarSectionTriggerLabel,
+            sidebarSectionMenu,
+            sidebarSectionOptionLibrary,
+            sidebarSectionOptionSocial,
+            sidebarPaneLibrary,
+            sidebarPaneSocial,
+            socialFeedStatus,
+            socialFeedList,
+        },
+        getToken: () => options?.token ?? 'token',
+        isSidebarVisible: options?.isSidebarVisible || (() => true),
+        fetchFollowingUsers,
+        fetchFollowingFeed,
+    });
+
+    return {
+        controller,
+        sidebarSectionTrigger,
+        sidebarSectionTriggerLabel,
+        sidebarSectionMenu,
+        sidebarSectionOptionLibrary,
+        sidebarSectionOptionSocial,
+        sidebarPaneLibrary,
+        sidebarPaneSocial,
+        socialFeedStatus,
+        socialFeedList,
+        fetchFollowingUsers,
+        fetchFollowingFeed,
+    };
+};
+
+describe('createListenBrainzSocialController', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-04-06T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        document.body.innerHTML = '';
+    });
+
+    it('loads and renders the social feed when the social tab opens', async () => {
+        const {
+            sidebarSectionTrigger,
+            sidebarSectionTriggerLabel,
+            sidebarSectionMenu,
+            sidebarSectionOptionSocial,
+            sidebarPaneLibrary,
+            sidebarPaneSocial,
+            socialFeedList,
+            fetchFollowingUsers,
+            fetchFollowingFeed,
+        } = mountController({
+            fetchFollowingFeed: vi.fn(async () => [
+                createEvent(),
+                createEvent({
+                    id: 2,
+                    userName: 'alice',
+                    created: 1710000200,
+                    listenedAt: 1710000150,
+                    trackMetadata: {
+                        artistName: 'Artist Two',
+                        trackName: 'Track Two',
+                        releaseName: 'Album Two',
+                        additionalInfo: {
+                            musicServiceName: 'Spotify',
+                        },
+                    },
+                }),
+                createEvent({
+                    id: 3,
+                    userName: 'bob',
+                    created: 1710000180,
+                    listenedAt: 1710000140,
+                    trackMetadata: {
+                        artistName: 'Artist Three',
+                        trackName: 'Track Three',
+                        releaseName: 'Album Three',
+                        additionalInfo: {
+                            musicServiceName: 'ListenBrainz',
+                        },
+                    },
+                }),
+            ]),
+        });
+
+        expect(sidebarSectionTriggerLabel.textContent).toBe('LIBRARY');
+
+        sidebarSectionTrigger.click();
+        expect(sidebarSectionMenu.hidden).toBe(false);
+
+        sidebarSectionOptionSocial.click();
+        await flushPromises();
+
+        await vi.waitFor(() => {
+            expect(socialFeedList.textContent).toContain('Track Two');
+        });
+
+        expect(fetchFollowingUsers).toHaveBeenCalledTimes(1);
+        expect(fetchFollowingFeed).toHaveBeenCalledWith(40);
+        expect(sidebarSectionTriggerLabel.textContent).toBe('SOCIAL');
+        expect(sidebarPaneLibrary.hidden).toBe(true);
+        expect(sidebarPaneSocial.hidden).toBe(false);
+        expect(socialFeedList.textContent).toContain('Track Two');
+        expect(socialFeedList.textContent).not.toContain('Track One');
+        expect(socialFeedList.textContent).toContain('Track Three');
+        expect(socialFeedList.textContent).toContain('alice');
+        expect(socialFeedList.textContent).toContain('bob');
+    });
+
+    it('shows a token-required empty state when ListenBrainz is not configured', async () => {
+        const {
+            sidebarSectionOptionSocial,
+            socialFeedList,
+            fetchFollowingUsers,
+            fetchFollowingFeed,
+        } = mountController({ token: '' });
+
+        sidebarSectionOptionSocial.click();
+        await flushPromises();
+
+        expect(fetchFollowingUsers).not.toHaveBeenCalled();
+        expect(fetchFollowingFeed).not.toHaveBeenCalled();
+        expect(socialFeedList.textContent).toContain('ListenBrainz token required');
+    });
+
+    it('polls again while the social tab stays active', async () => {
+        const { sidebarSectionOptionSocial, fetchFollowingFeed } = mountController();
+
+        sidebarSectionOptionSocial.click();
+        await flushPromises();
+
+        expect(fetchFollowingFeed).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(15000);
+        await flushPromises();
+
+        expect(fetchFollowingFeed).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps background polling silent once the feed has loaded', async () => {
+        let resolveSecondFeedRequest: ((events: ListenBrainzSocialEvent[]) => void) | null = null;
+        const fetchFollowingFeed = vi.fn<() => Promise<ListenBrainzSocialEvent[]>>()
+            .mockResolvedValueOnce([createEvent()])
+            .mockImplementationOnce(async () => await new Promise<ListenBrainzSocialEvent[]>((resolve) => {
+                resolveSecondFeedRequest = resolve;
+            }));
+        const { sidebarSectionOptionSocial, socialFeedStatus } = mountController({ fetchFollowingFeed });
+
+        sidebarSectionOptionSocial.click();
+        await flushPromises();
+
+        await vi.waitFor(() => {
+            expect(socialFeedStatus.textContent).toBe('');
+        });
+
+        await vi.advanceTimersByTimeAsync(15000);
+        await flushPromises();
+
+        expect(fetchFollowingFeed).toHaveBeenCalledTimes(2);
+        expect(socialFeedStatus.textContent).toBe('');
+
+        resolveSecondFeedRequest?.([createEvent({ id: 2, trackMetadata: {
+            artistName: 'Artist Two',
+            trackName: 'Track Two',
+            releaseName: 'Album Two',
+            additionalInfo: {
+                musicServiceName: 'Spotify',
+            },
+        } })]);
+        await flushPromises();
+
+        expect(socialFeedStatus.textContent).toBe('');
+    });
+
+    it('animates the feed when new scrobbles arrive', async () => {
+        let nextEvents = [createEvent()];
+        const fetchFollowingFeed = vi.fn(async () => nextEvents);
+        const { controller, sidebarSectionOptionSocial, socialFeedList } = mountController({ fetchFollowingFeed });
+
+        sidebarSectionOptionSocial.click();
+        await flushPromises();
+
+        await vi.waitFor(() => {
+            expect(socialFeedList.textContent).toContain('Track One');
+        });
+
+        nextEvents = [createEvent({
+            id: 2,
+            created: 1710000200,
+            listenedAt: 1710000150,
+            trackMetadata: {
+                artistName: 'Artist Two',
+                trackName: 'Track Two',
+                releaseName: 'Album Two',
+                additionalInfo: {
+                    musicServiceName: 'Spotify',
+                },
+            },
+        })];
+
+        await controller.refresh();
+        await flushPromises();
+
+        expect(socialFeedList.classList.contains('is-animating')).toBe(true);
+        expect(socialFeedList.textContent).toContain('Track Two');
+
+        await vi.advanceTimersByTimeAsync(420);
+
+        expect(socialFeedList.classList.contains('is-animating')).toBe(false);
+    });
+
+    it('switches back to the library pane when requested programmatically', async () => {
+        const { controller, sidebarSectionOptionSocial, sidebarSectionTriggerLabel, sidebarPaneLibrary, sidebarPaneSocial } = mountController();
+
+        sidebarSectionOptionSocial.click();
+        await flushPromises();
+
+        controller.showLibrary();
+
+        expect(sidebarSectionTriggerLabel.textContent).toBe('LIBRARY');
+        expect(sidebarPaneLibrary.hidden).toBe(false);
+        expect(sidebarPaneSocial.hidden).toBe(true);
+        expect(controller.isSocialActive()).toBe(false);
+    });
+});

--- a/frontend/src/controllers/listenbrainz-social-controller.ts
+++ b/frontend/src/controllers/listenbrainz-social-controller.ts
@@ -1,0 +1,496 @@
+import type { SidebarElements } from '../components/sidebar';
+import type { ListenBrainzSocialEvent } from '../types/app-types';
+
+type SidebarSection = 'library' | 'social';
+
+type ListenBrainzSocialControllerOptions = {
+    elements: Pick<SidebarElements, 'sidebarToggle' | 'sidebarSectionTrigger' | 'sidebarSectionTriggerLabel' | 'sidebarSectionMenu' | 'sidebarSectionOptionLibrary' | 'sidebarSectionOptionSocial' | 'sidebarPaneLibrary' | 'sidebarPaneSocial' | 'socialFeedStatus' | 'socialFeedList'>;
+    getToken: () => string;
+    isSidebarVisible: () => boolean;
+    fetchFollowingUsers: () => Promise<string[]>;
+    fetchFollowingFeed: (count: number) => Promise<ListenBrainzSocialEvent[]>;
+};
+
+export type ListenBrainzSocialController = ReturnType<typeof createListenBrainzSocialController>;
+
+const socialFeedPollIntervalMs = 15000;
+const socialFeedItemCount = 40;
+const socialFeedUpdateAnimationMs = 420;
+const sidebarSectionSwitchAnimationMs = 240;
+
+const listenBrainzUserIcon = '<svg class="social-feed-listenbrainz-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 27 30" aria-hidden="true"><polygon fill="#353070" points="13 1 1 8 1 22 13 29 13 1"/><polygon fill="#eb743b" points="14 1 26 8 26 22 14 29 14 1"/></svg>';
+
+const escapeHtml = (value: string): string => value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+const formatMusicServiceLabel = (event: ListenBrainzSocialEvent): string => {
+    const explicitName = (event.trackMetadata.additionalInfo.musicServiceName || '').trim();
+    if (explicitName !== '') {
+        return explicitName;
+    }
+
+    const domain = (event.trackMetadata.additionalInfo.musicService || '').trim().toLowerCase();
+    if (domain === '') {
+        return '';
+    }
+
+    return domain.replace(/^www\./, '').replace(/\.[a-z0-9]+$/, '');
+};
+
+const formatRelativeTime = (timestampSeconds: number): string => {
+    if (!Number.isFinite(timestampSeconds) || timestampSeconds <= 0) {
+        return 'just now';
+    }
+
+    const deltaSeconds = Math.max(0, Math.floor(Date.now() / 1000) - Math.floor(timestampSeconds));
+    if (deltaSeconds < 15) {
+        return 'just now';
+    }
+
+    if (deltaSeconds < 60) {
+        return `${deltaSeconds}s ago`;
+    }
+
+    const deltaMinutes = Math.floor(deltaSeconds / 60);
+    if (deltaMinutes < 60) {
+        return `${deltaMinutes}m ago`;
+    }
+
+    const deltaHours = Math.floor(deltaMinutes / 60);
+    if (deltaHours < 24) {
+        return `${deltaHours}h ago`;
+    }
+
+    const deltaDays = Math.floor(deltaHours / 24);
+    if (deltaDays < 7) {
+        return `${deltaDays}d ago`;
+    }
+
+    return new Date(timestampSeconds * 1000).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+};
+
+const normalizeErrorMessage = (error: unknown): string => {
+    if (error instanceof Error) {
+        return error.message.trim() || 'ListenBrainz social feed request failed.';
+    }
+
+    if (typeof error === 'string') {
+        return error.trim() || 'ListenBrainz social feed request failed.';
+    }
+
+    return 'ListenBrainz social feed request failed.';
+};
+
+const normalizedEventTimestamp = (event: ListenBrainzSocialEvent): number => {
+    if (Number.isFinite(event.listenedAt || 0) && (event.listenedAt || 0) > 0) {
+        return Math.floor(event.listenedAt || 0);
+    }
+
+    if (Number.isFinite(event.created) && event.created > 0) {
+        return Math.floor(event.created);
+    }
+
+    return 0;
+};
+
+const normalizedUserKey = (event: ListenBrainzSocialEvent): string => (event.userName || '').trim().toLowerCase();
+
+const isNewerSocialEvent = (candidate: ListenBrainzSocialEvent, current: ListenBrainzSocialEvent): boolean => {
+    const candidateTimestamp = normalizedEventTimestamp(candidate);
+    const currentTimestamp = normalizedEventTimestamp(current);
+
+    if (candidateTimestamp !== currentTimestamp) {
+        return candidateTimestamp > currentTimestamp;
+    }
+
+    if (Boolean(candidate.playingNow) !== Boolean(current.playingNow)) {
+        return Boolean(candidate.playingNow);
+    }
+
+    return candidate.id > current.id;
+};
+
+const dedupeAndSortEvents = (events: ListenBrainzSocialEvent[]): ListenBrainzSocialEvent[] => {
+    const latestEventsByUser = new Map<string, ListenBrainzSocialEvent>();
+    const unkeyedEvents: ListenBrainzSocialEvent[] = [];
+
+    for (const event of events) {
+        if (event.hidden) {
+            continue;
+        }
+
+        const userKey = normalizedUserKey(event);
+        if (userKey === '') {
+            unkeyedEvents.push(event);
+            continue;
+        }
+
+        const existingEvent = latestEventsByUser.get(userKey);
+        if (!existingEvent || isNewerSocialEvent(event, existingEvent)) {
+            latestEventsByUser.set(userKey, event);
+        }
+    }
+
+    return [...latestEventsByUser.values(), ...unkeyedEvents]
+        .sort((left, right) => {
+            const timestampDelta = normalizedEventTimestamp(right) - normalizedEventTimestamp(left);
+            if (timestampDelta !== 0) {
+                return timestampDelta;
+            }
+
+            return right.id - left.id;
+        });
+};
+
+const socialFeedEventSignature = (events: ListenBrainzSocialEvent[]): string => events.map((event) => [
+    normalizedUserKey(event),
+    event.id,
+    normalizedEventTimestamp(event),
+    event.playingNow ? 1 : 0,
+    event.trackMetadata.trackName || '',
+].join(':')).join('|');
+
+export const createListenBrainzSocialController = (options: ListenBrainzSocialControllerOptions) => {
+    const {
+        sidebarToggle,
+        sidebarSectionTrigger,
+        sidebarSectionTriggerLabel,
+        sidebarSectionMenu,
+        sidebarSectionOptionLibrary,
+        sidebarSectionOptionSocial,
+        sidebarPaneLibrary,
+        sidebarPaneSocial,
+        socialFeedStatus,
+        socialFeedList,
+    } = options.elements;
+
+    let activeSection: SidebarSection = 'library';
+    let sectionMenuOpen = false;
+    let refreshInFlight = false;
+    let lastErrorMessage = '';
+    let followingUsers: string[] = [];
+    let socialEvents: ListenBrainzSocialEvent[] = [];
+    let animateNextRender = false;
+    let pollHandle: number | undefined;
+    let updateAnimationHandle: number | undefined;
+    let sectionSwitchAnimationHandle: number | undefined;
+
+    const stopPolling = (): void => {
+        if (pollHandle !== undefined) {
+            window.clearTimeout(pollHandle);
+            pollHandle = undefined;
+        }
+    };
+
+    const clearUpdateAnimation = (): void => {
+        if (updateAnimationHandle !== undefined) {
+            window.clearTimeout(updateAnimationHandle);
+            updateAnimationHandle = undefined;
+        }
+
+        socialFeedList.classList.remove('is-animating');
+    };
+
+    const clearSectionSwitchAnimation = (): void => {
+        if (sectionSwitchAnimationHandle !== undefined) {
+            window.clearTimeout(sectionSwitchAnimationHandle);
+            sectionSwitchAnimationHandle = undefined;
+        }
+
+        sidebarPaneLibrary.classList.remove('is-section-entering');
+        sidebarPaneSocial.classList.remove('is-section-entering');
+    };
+
+    const animateSectionSwitch = (): void => {
+        clearSectionSwitchAnimation();
+
+        const enteringPane = activeSection === 'library' ? sidebarPaneLibrary : sidebarPaneSocial;
+        enteringPane.classList.add('is-section-entering');
+        sectionSwitchAnimationHandle = window.setTimeout(() => {
+            enteringPane.classList.remove('is-section-entering');
+            sectionSwitchAnimationHandle = undefined;
+        }, sidebarSectionSwitchAnimationMs);
+    };
+
+    const setSectionMenuOpen = (open: boolean): void => {
+        sectionMenuOpen = open;
+        sidebarSectionMenu.hidden = !open;
+        sidebarSectionTrigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+        sidebarSectionTrigger.classList.toggle('is-open', open);
+    };
+
+    const renderEmptyState = (title: string, detail: string): string => `
+        <div class="social-feed-empty">
+            <p class="social-feed-empty-title">${escapeHtml(title)}</p>
+            <p class="social-feed-empty-detail">${escapeHtml(detail)}</p>
+        </div>
+    `;
+
+    const renderEvents = (): string => {
+        if (socialEvents.length === 0) {
+            if (options.getToken().trim() === '') {
+                return renderEmptyState(
+                    'ListenBrainz token required',
+                    'Add your ListenBrainz user token in Settings to load the people you follow and their recent scrobbles.',
+                );
+            }
+
+            if (followingUsers.length === 0) {
+                return renderEmptyState(
+                    'No followed users yet',
+                    'This view reads your ListenBrainz following feed. Follow a few people there and their new scrobbles will appear here.',
+                );
+            }
+
+            return renderEmptyState(
+                'No recent scrobbles',
+                'Your followed users have not submitted any recent listens to ListenBrainz yet.',
+            );
+        }
+
+        return socialEvents.map((event) => {
+            const timestampSeconds = normalizedEventTimestamp(event);
+            const relativeTime = formatRelativeTime(timestampSeconds);
+            const absoluteTime = timestampSeconds > 0
+                ? new Date(timestampSeconds * 1000).toLocaleString()
+                : 'Unknown time';
+            const trackName = (event.trackMetadata.trackName || '').trim() || 'Unknown track';
+            const artistName = (event.trackMetadata.artistName || '').trim() || 'Unknown artist';
+            const releaseName = (event.trackMetadata.releaseName || '').trim();
+            const serviceLabel = formatMusicServiceLabel(event);
+            const secondaryLine = releaseName !== ''
+                ? `${artistName} • ${releaseName}`
+                : artistName;
+            const badges: string[] = [];
+            if (event.playingNow) {
+                badges.push('<span class="social-feed-badge is-live">Live</span>');
+            }
+            if (serviceLabel !== '') {
+                badges.push(`<span class="social-feed-badge">${escapeHtml(serviceLabel)}</span>`);
+            }
+
+            return `
+                <article class="social-feed-card${event.playingNow ? ' is-live' : ''}">
+                    <div class="social-feed-card-header">
+                        <div class="social-feed-identity">
+                            <span class="social-feed-avatar" aria-hidden="true">${listenBrainzUserIcon}</span>
+                            <div class="social-feed-user-copy">
+                                <p class="social-feed-user">${escapeHtml((event.userName || '').trim() || 'Unknown user')}</p>
+                                <p class="social-feed-verb">${event.playingNow ? 'is listening now' : 'scrobbled recently'}</p>
+                            </div>
+                        </div>
+                        <span class="social-feed-time" title="${escapeHtml(absoluteTime)}">${escapeHtml(relativeTime)}</span>
+                    </div>
+                    <p class="social-feed-track">${escapeHtml(trackName)}</p>
+                    <p class="social-feed-meta">${escapeHtml(secondaryLine)}</p>
+                    ${badges.length > 0 ? `<div class="social-feed-badges">${badges.join('')}</div>` : ''}
+                </article>
+            `;
+        }).join('');
+    };
+
+    const render = (): void => {
+        const showingLibrary = activeSection === 'library';
+
+        sidebarSectionTriggerLabel.textContent = showingLibrary ? 'LIBRARY' : 'SOCIAL';
+        sidebarSectionOptionLibrary.classList.toggle('is-active', showingLibrary);
+        sidebarSectionOptionLibrary.setAttribute('aria-checked', showingLibrary ? 'true' : 'false');
+        sidebarSectionOptionSocial.classList.toggle('is-active', !showingLibrary);
+        sidebarSectionOptionSocial.setAttribute('aria-checked', showingLibrary ? 'false' : 'true');
+
+        sidebarPaneLibrary.hidden = !showingLibrary;
+        sidebarPaneSocial.hidden = showingLibrary;
+
+        if (lastErrorMessage !== '') {
+            socialFeedStatus.textContent = socialEvents.length > 0 ? `Showing cached results. ${lastErrorMessage}` : lastErrorMessage;
+        } else if (refreshInFlight && socialEvents.length === 0) {
+            socialFeedStatus.textContent = 'Loading...';
+        } else {
+            socialFeedStatus.textContent = '';
+        }
+
+        socialFeedList.innerHTML = renderEvents();
+        if (animateNextRender) {
+            clearUpdateAnimation();
+            void socialFeedList.offsetWidth;
+            socialFeedList.classList.add('is-animating');
+            updateAnimationHandle = window.setTimeout(() => {
+                socialFeedList.classList.remove('is-animating');
+                updateAnimationHandle = undefined;
+            }, socialFeedUpdateAnimationMs);
+            animateNextRender = false;
+        }
+    };
+
+    const scheduleNextPoll = (): void => {
+        stopPolling();
+        if (activeSection !== 'social' || options.getToken().trim() === '' || !options.isSidebarVisible()) {
+            return;
+        }
+
+        pollHandle = window.setTimeout(() => {
+            void refreshSocialFeed(false).finally(() => {
+                scheduleNextPoll();
+            });
+        }, socialFeedPollIntervalMs);
+    };
+
+    const refreshSocialFeed = async (manualRefresh: boolean): Promise<void> => {
+        if (refreshInFlight) {
+            return;
+        }
+
+        const token = options.getToken().trim();
+        if (token === '') {
+            followingUsers = [];
+            socialEvents = [];
+            lastErrorMessage = '';
+            render();
+            return;
+        }
+
+        if (!manualRefresh && !options.isSidebarVisible()) {
+            render();
+            return;
+        }
+
+        refreshInFlight = true;
+        lastErrorMessage = '';
+        render();
+
+        try {
+            const [rawFollowingUsers, rawEvents] = await Promise.all([
+                options.fetchFollowingUsers(),
+                options.fetchFollowingFeed(socialFeedItemCount),
+            ]);
+            const nextEvents = dedupeAndSortEvents(rawEvents || []);
+
+            followingUsers = [...new Set((rawFollowingUsers || []).map((userName) => userName.trim()).filter((userName) => userName !== ''))]
+                .sort((left, right) => left.localeCompare(right));
+            animateNextRender = nextEvents.length > 0 && socialFeedEventSignature(nextEvents) !== socialFeedEventSignature(socialEvents);
+            socialEvents = nextEvents;
+        } catch (error) {
+            lastErrorMessage = normalizeErrorMessage(error);
+            animateNextRender = false;
+        } finally {
+            refreshInFlight = false;
+            render();
+        }
+    };
+
+    const showLibrary = (): void => {
+        if (activeSection === 'library') {
+            setSectionMenuOpen(false);
+            return;
+        }
+
+        activeSection = 'library';
+        stopPolling();
+        setSectionMenuOpen(false);
+        render();
+        animateSectionSwitch();
+    };
+
+    const showSocial = (): void => {
+        if (activeSection === 'social') {
+            setSectionMenuOpen(false);
+            return;
+        }
+
+        activeSection = 'social';
+        setSectionMenuOpen(false);
+        render();
+        animateSectionSwitch();
+        void refreshSocialFeed(false);
+        scheduleNextPoll();
+    };
+
+    const handleSettingsChanged = (): void => {
+        if (options.getToken().trim() === '') {
+            followingUsers = [];
+            socialEvents = [];
+            lastErrorMessage = '';
+            stopPolling();
+            clearUpdateAnimation();
+            clearSectionSwitchAnimation();
+            setSectionMenuOpen(false);
+            render();
+            return;
+        }
+
+        if (activeSection === 'social') {
+            void refreshSocialFeed(true);
+            scheduleNextPoll();
+            return;
+        }
+
+        render();
+    };
+
+    sidebarSectionTrigger.addEventListener('click', () => {
+        setSectionMenuOpen(!sectionMenuOpen);
+    });
+    sidebarSectionOptionLibrary.addEventListener('click', showLibrary);
+    sidebarSectionOptionSocial.addEventListener('click', showSocial);
+    document.addEventListener('click', (event) => {
+        if (!sectionMenuOpen) {
+            return;
+        }
+
+        const target = event.target;
+        if (!(target instanceof Node)) {
+            return;
+        }
+
+        if (sidebarSectionTrigger.contains(target) || sidebarSectionMenu.contains(target)) {
+            return;
+        }
+
+        setSectionMenuOpen(false);
+    });
+    document.addEventListener('keydown', (event) => {
+        if (event.key !== 'Escape' || !sectionMenuOpen) {
+            return;
+        }
+
+        event.preventDefault();
+        setSectionMenuOpen(false);
+        sidebarSectionTrigger.focus();
+    });
+    sidebarToggle.addEventListener('click', () => {
+        window.setTimeout(() => {
+            if (!options.isSidebarVisible()) {
+                stopPolling();
+                setSectionMenuOpen(false);
+                clearSectionSwitchAnimation();
+                return;
+            }
+
+            if (activeSection === 'social' && options.isSidebarVisible()) {
+                void refreshSocialFeed(false);
+                scheduleNextPoll();
+            }
+        }, 0);
+    });
+
+    render();
+
+    return {
+        handleSettingsChanged,
+        isSocialActive: (): boolean => activeSection === 'social',
+        refresh: async (): Promise<void> => {
+            await refreshSocialFeed(true);
+        },
+        showLibrary,
+        showSocial,
+    };
+};

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,6 +8,7 @@ import { createImageModalController, type ImageModalController } from './control
 import { createLibraryController } from './controllers/library-controller';
 import type { LibraryController } from './controllers/library-controller';
 import { createListenBrainzController, type ListenBrainzFeedbackScore } from './controllers/listenbrainz-controller';
+import { createListenBrainzSocialController } from './controllers/listenbrainz-social-controller';
 import { createMediaSessionController, type ExternalPlaybackAction } from './controllers/media-session-controller';
 import { createPlaylistController, type LoadedPlaylistData, type PlaylistController } from './controllers/playlist-controller';
 import { createPlaylistTargetModalController, type PlaylistTargetModalController } from './controllers/playlist-target-modal-controller';
@@ -83,6 +84,8 @@ import {
     GetLibraryFolderTrackCount,
     GetLibraryFolderTrackPaths,
     GetLibraryIndexedFilePage,
+    GetListenBrainzFollowing,
+    GetListenBrainzFollowingFeed,
     ResolveLibraryFolderForPath,
     GetListenBrainzRecordingFeedback,
     IsLibraryFolderImmediateDescendantsEnumerated,
@@ -127,6 +130,7 @@ import type {
     LibrarySearchPage,
     MusicBrainzTagWorkerProgress,
     MusicBrainzEntityType,
+    ListenBrainzSocialEvent,
     PlayerCardLayout,
     PlaybackOrderMode,
     PlaylistLoadResult,
@@ -488,11 +492,20 @@ const {
     librarySidebar,
     librarySettings,
     libraryAbout,
+    sidebarSectionTrigger,
+    sidebarSectionTriggerLabel,
+    sidebarSectionMenu,
+    sidebarSectionOptionLibrary,
+    sidebarSectionOptionSocial,
+    sidebarPaneLibrary,
+    sidebarPaneSocial,
     libraryBack,
     libraryPath,
     librarySearch,
     libraryBrowser,
     libraryScanYieldIndicator,
+    socialFeedStatus,
+    socialFeedList,
 } = getSidebarElements(document);
 const {
     playerShell,
@@ -585,6 +598,34 @@ const refreshListenBrainzFeedbackForCurrentTrack = async (force = false): Promis
 const submitListenBrainzFeedbackForTrack = async (trackIndex: number, score: ListenBrainzFeedbackScore): Promise<void> => {
     await listenBrainzController.submitFeedbackForTrack(trackIndex, score);
 };
+const listenBrainzSocialController = createListenBrainzSocialController({
+    elements: {
+        sidebarToggle,
+        sidebarSectionTrigger,
+        sidebarSectionTriggerLabel,
+        sidebarSectionMenu,
+        sidebarSectionOptionLibrary,
+        sidebarSectionOptionSocial,
+        sidebarPaneLibrary,
+        sidebarPaneSocial,
+        socialFeedStatus,
+        socialFeedList,
+    },
+    getToken: () => currentSettings.listenBrainzUserToken,
+    isSidebarVisible: () => app.classList.contains('sidebar-open'),
+    fetchFollowingUsers: async (): Promise<string[]> => await scheduleListenBrainzRequest(async () => (
+        await GetListenBrainzFollowing() as string[]
+    ), {
+        server: currentSettings.listenBrainzServerUrl || defaultListenBrainzServerUrl,
+        path: '/1/user/{user}/following',
+    }),
+    fetchFollowingFeed: async (count: number): Promise<ListenBrainzSocialEvent[]> => await scheduleListenBrainzRequest(async () => (
+        await GetListenBrainzFollowingFeed(count) as ListenBrainzSocialEvent[]
+    ), {
+        server: currentSettings.listenBrainzServerUrl || defaultListenBrainzServerUrl,
+        path: '/1/user/{user}/feed/events/listens/following',
+    }),
+});
 const openMbOnCtrlClick = (event: MouseEvent, target: HTMLElement): void => {
     if (!event.ctrlKey) {
         return;
@@ -3109,6 +3150,7 @@ const initializeSettings = async (): Promise<void> => {
 
         const settings = await GetSettings() as AppSettings;
         currentSettings = normalizeAppSettings(settings);
+        listenBrainzSocialController.handleSettingsChanged();
         currentMusicBrainzTagWorkerProgress = normalizeMusicBrainzTagWorkerProgress(
             await GetMusicBrainzTagWorkerProgress() as MusicBrainzTagWorkerProgress,
         );
@@ -3499,6 +3541,8 @@ const handleFocusedKeyboardShortcut = (event: KeyboardEvent): boolean => {
         if (!libraryController.isSidebarOpen()) {
             libraryController.setSidebarOpen(true);
         }
+
+        listenBrainzSocialController.showLibrary();
 
         window.requestAnimationFrame(() => {
             librarySearch.focus();
@@ -3962,6 +4006,7 @@ settingsController = createSettingsController({
         })) as AppSettings;
 
         currentSettings = normalizeAppSettings(savedSettings);
+        listenBrainzSocialController.handleSettingsChanged();
         setPlaybackOrderMode(currentSettings.playbackOrder);
         if (currentTrackIndex >= 0 && currentTrackIndex < tracks.length) {
             void applyCoverArtForTrack(currentTrackIndex);
@@ -4053,6 +4098,7 @@ settingsController = createSettingsController({
         })) as AppSettings;
 
         currentSettings = normalizeAppSettings(savedSettings);
+        listenBrainzSocialController.handleSettingsChanged();
         setPlaybackOrderMode(currentSettings.playbackOrder);
         const outputDevices = await refreshAvailableAudioOutputDevices();
 

--- a/frontend/src/types/app-types.ts
+++ b/frontend/src/types/app-types.ts
@@ -58,6 +58,38 @@ export type Track = {
     mbArtistCredits: MusicBrainzArtistCredit[];
 };
 
+export type ListenBrainzSocialAdditionalInfo = {
+    recordingMbid?: string;
+    recordingMsid?: string;
+    releaseMbid?: string;
+    releaseGroupMbid?: string;
+    artistMbids?: string[];
+    originUrl?: string;
+    musicService?: string;
+    musicServiceName?: string;
+    durationMs?: number;
+};
+
+export type ListenBrainzSocialTrackMetadata = {
+    artistName: string;
+    trackName: string;
+    releaseName?: string;
+    additionalInfo: ListenBrainzSocialAdditionalInfo;
+};
+
+export type ListenBrainzSocialEvent = {
+    id: number;
+    created: number;
+    eventType: string;
+    hidden: boolean;
+    message?: string;
+    userName: string;
+    listenedAt?: number;
+    listenedAtIso?: string;
+    playingNow?: boolean;
+    trackMetadata: ListenBrainzSocialTrackMetadata;
+};
+
 export type TrackTags = {
     artist: string;
     album: string;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -42,6 +42,10 @@ export function GetLibraryFolderTrackPaths(arg1:string):Promise<Array<string>>;
 
 export function GetLibraryIndexedFilePage(arg1:string,arg2:number,arg3:number):Promise<main.LibraryIndexedFilePage>;
 
+export function GetListenBrainzFollowing():Promise<Array<string>>;
+
+export function GetListenBrainzFollowingFeed(arg1:number):Promise<Array<main.ListenBrainzSocialEvent>>;
+
 export function GetListenBrainzRecordingFeedback(arg1:string):Promise<number>;
 
 export function GetMusicBrainzTagWorkerProgress():Promise<main.MusicBrainzTagWorkerProgress>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -82,6 +82,14 @@ export function GetLibraryIndexedFilePage(arg1, arg2, arg3) {
   return window['go']['main']['App']['GetLibraryIndexedFilePage'](arg1, arg2, arg3);
 }
 
+export function GetListenBrainzFollowing() {
+  return window['go']['main']['App']['GetListenBrainzFollowing']();
+}
+
+export function GetListenBrainzFollowingFeed(arg1) {
+  return window['go']['main']['App']['GetListenBrainzFollowingFeed'](arg1);
+}
+
 export function GetListenBrainzRecordingFeedback(arg1) {
   return window['go']['main']['App']['GetListenBrainzRecordingFeedback'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -430,6 +430,119 @@ export namespace main {
 		    return a;
 		}
 	}
+	export class ListenBrainzSocialAdditionalInfo {
+	    recordingMbid?: string;
+	    recordingMsid?: string;
+	    releaseMbid?: string;
+	    releaseGroupMbid?: string;
+	    artistMbids?: string[];
+	    originUrl?: string;
+	    musicService?: string;
+	    musicServiceName?: string;
+	    durationMs?: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new ListenBrainzSocialAdditionalInfo(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.recordingMbid = source["recordingMbid"];
+	        this.recordingMsid = source["recordingMsid"];
+	        this.releaseMbid = source["releaseMbid"];
+	        this.releaseGroupMbid = source["releaseGroupMbid"];
+	        this.artistMbids = source["artistMbids"];
+	        this.originUrl = source["originUrl"];
+	        this.musicService = source["musicService"];
+	        this.musicServiceName = source["musicServiceName"];
+	        this.durationMs = source["durationMs"];
+	    }
+	}
+	export class ListenBrainzSocialTrackMetadata {
+	    artistName: string;
+	    trackName: string;
+	    releaseName?: string;
+	    additionalInfo: ListenBrainzSocialAdditionalInfo;
+	
+	    static createFrom(source: any = {}) {
+	        return new ListenBrainzSocialTrackMetadata(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.artistName = source["artistName"];
+	        this.trackName = source["trackName"];
+	        this.releaseName = source["releaseName"];
+	        this.additionalInfo = this.convertValues(source["additionalInfo"], ListenBrainzSocialAdditionalInfo);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class ListenBrainzSocialEvent {
+	    id: number;
+	    created: number;
+	    eventType: string;
+	    hidden: boolean;
+	    message?: string;
+	    userName: string;
+	    listenedAt?: number;
+	    listenedAtIso?: string;
+	    playingNow?: boolean;
+	    trackMetadata: ListenBrainzSocialTrackMetadata;
+	
+	    static createFrom(source: any = {}) {
+	        return new ListenBrainzSocialEvent(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.created = source["created"];
+	        this.eventType = source["eventType"];
+	        this.hidden = source["hidden"];
+	        this.message = source["message"];
+	        this.userName = source["userName"];
+	        this.listenedAt = source["listenedAt"];
+	        this.listenedAtIso = source["listenedAtIso"];
+	        this.playingNow = source["playingNow"];
+	        this.trackMetadata = this.convertValues(source["trackMetadata"], ListenBrainzSocialTrackMetadata);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
 	export class ListenBrainzTrackMetadata {
 	    artistName: string;
 	    trackName: string;

--- a/listenbrainz.go
+++ b/listenbrainz.go
@@ -18,6 +18,8 @@ const listenBrainzSubmitPath = "/1/submit-listens"
 const listenBrainzRecordingFeedbackPath = "/1/feedback/recording-feedback"
 const listenBrainzValidateTokenPath = "/1/validate-token"
 const listenBrainzGetFeedbackForRecordingsPath = "/1/feedback/user/%s/get-feedback-for-recordings"
+const listenBrainzFollowingPath = "/1/user/%s/following"
+const listenBrainzFeedEventsFollowingPath = "/1/user/%s/feed/events/listens/following"
 
 var listenBrainzFetchMu sync.Mutex
 var nextListenBrainzFetchAt time.Time
@@ -98,6 +100,96 @@ type listenBrainzRecordingFeedbackLookupResponse struct {
 	Feedback []listenBrainzRecordingFeedbackItem `json:"feedback"`
 }
 
+// ListenBrainzSocialAdditionalInfo stores the auxiliary metadata returned for a social listen event.
+type ListenBrainzSocialAdditionalInfo struct {
+	RecordingMBID    string   `json:"recordingMbid,omitempty"`
+	RecordingMSID    string   `json:"recordingMsid,omitempty"`
+	ReleaseMBID      string   `json:"releaseMbid,omitempty"`
+	ReleaseGroupMBID string   `json:"releaseGroupMbid,omitempty"`
+	ArtistMBIDs      []string `json:"artistMbids,omitempty"`
+	OriginURL        string   `json:"originUrl,omitempty"`
+	MusicService     string   `json:"musicService,omitempty"`
+	MusicServiceName string   `json:"musicServiceName,omitempty"`
+	DurationMs       int      `json:"durationMs,omitempty"`
+}
+
+// ListenBrainzSocialTrackMetadata stores the track details for one social listen event.
+type ListenBrainzSocialTrackMetadata struct {
+	ArtistName     string                           `json:"artistName"`
+	TrackName      string                           `json:"trackName"`
+	ReleaseName    string                           `json:"releaseName,omitempty"`
+	AdditionalInfo ListenBrainzSocialAdditionalInfo `json:"additionalInfo"`
+}
+
+// ListenBrainzSocialEvent stores one listen event returned by the ListenBrainz social feed.
+type ListenBrainzSocialEvent struct {
+	ID            int                             `json:"id"`
+	Created       int64                           `json:"created"`
+	EventType     string                          `json:"eventType"`
+	Hidden        bool                            `json:"hidden"`
+	Message       string                          `json:"message,omitempty"`
+	UserName      string                          `json:"userName"`
+	ListenedAt    int64                           `json:"listenedAt,omitempty"`
+	ListenedAtISO string                          `json:"listenedAtIso,omitempty"`
+	PlayingNow    bool                            `json:"playingNow,omitempty"`
+	TrackMetadata ListenBrainzSocialTrackMetadata `json:"trackMetadata"`
+}
+
+type listenBrainzFollowingResponse struct {
+	Following []string `json:"following"`
+	User      string   `json:"user"`
+}
+
+type listenBrainzSocialAdditionalInfoResponse struct {
+	RecordingMBID    string   `json:"recording_mbid,omitempty"`
+	RecordingMSID    string   `json:"recording_msid,omitempty"`
+	ReleaseMBID      string   `json:"release_mbid,omitempty"`
+	ReleaseGroupMBID string   `json:"release_group_mbid,omitempty"`
+	ArtistMBIDs      []string `json:"artist_mbids,omitempty"`
+	OriginURL        string   `json:"origin_url,omitempty"`
+	MusicService     string   `json:"music_service,omitempty"`
+	MusicServiceName string   `json:"music_service_name,omitempty"`
+	DurationMs       int      `json:"duration_ms,omitempty"`
+}
+
+type listenBrainzSocialTrackMetadataResponse struct {
+	AdditionalInfo listenBrainzSocialAdditionalInfoResponse `json:"additional_info"`
+	ArtistName     string                                   `json:"artist_name"`
+	ReleaseName    string                                   `json:"release_name"`
+	TrackName      string                                   `json:"track_name"`
+}
+
+type listenBrainzSocialMetadataResponse struct {
+	Created          int64                                   `json:"created,omitempty"`
+	RelationshipType string                                  `json:"relationship_type,omitempty"`
+	Message          string                                  `json:"message,omitempty"`
+	BlurbContent     string                                  `json:"blurb_content,omitempty"`
+	InsertedAt       int64                                   `json:"inserted_at,omitempty"`
+	ListenedAt       int64                                   `json:"listened_at,omitempty"`
+	ListenedAtISO    string                                  `json:"listened_at_iso,omitempty"`
+	PlayingNow       bool                                    `json:"playing_now,omitempty"`
+	TrackMetadata    listenBrainzSocialTrackMetadataResponse `json:"track_metadata"`
+	UserName         string                                  `json:"user_name,omitempty"`
+}
+
+type listenBrainzSocialEventResponse struct {
+	Created   int64                              `json:"created"`
+	EventType string                             `json:"event_type"`
+	Hidden    bool                               `json:"hidden"`
+	ID        int                                `json:"id"`
+	Message   string                             `json:"message,omitempty"`
+	Metadata  listenBrainzSocialMetadataResponse `json:"metadata"`
+	UserName  string                             `json:"user_name"`
+}
+
+type listenBrainzSocialFeedResponse struct {
+	Payload struct {
+		Count  int                               `json:"count"`
+		Events []listenBrainzSocialEventResponse `json:"events"`
+		UserID string                            `json:"user_id"`
+	} `json:"payload"`
+}
+
 func waitForListenBrainzRequestSlot(rateLimitMs int) {
 	if rateLimitMs <= 0 {
 		return
@@ -136,6 +228,18 @@ func parseListenBrainzError(statusCode int, responseBody []byte, fallback string
 	}
 
 	return fmt.Errorf("%s with status %d", fallback, statusCode)
+}
+
+func normalizeListenBrainzSocialCount(count int) int {
+	if count <= 0 {
+		return 25
+	}
+
+	if count > 1000 {
+		return 1000
+	}
+
+	return count
 }
 
 func (a *App) listenBrainzServerURL() string {
@@ -435,4 +539,170 @@ func (a *App) GetListenBrainzRecordingFeedback(recordingMBID string) (int, error
 	}
 
 	return 0, nil
+}
+
+// GetListenBrainzFollowing fetches the usernames followed by the configured ListenBrainz account.
+func (a *App) GetListenBrainzFollowing() ([]string, error) {
+	token, err := a.listenBrainzToken()
+	if err != nil {
+		return nil, err
+	}
+
+	userName, err := a.listenBrainzUserName(token)
+	if err != nil {
+		return nil, err
+	}
+
+	requestURL := fmt.Sprintf(
+		a.listenBrainzServerURL()+listenBrainzFollowingPath,
+		url.PathEscape(userName),
+	)
+
+	a.waitForListenBrainzRequestSlotIfNeeded()
+
+	httpRequest, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpRequest.Header.Set("Accept", "application/json")
+	httpRequest.Header.Set("Authorization", fmt.Sprintf("Token %s", token))
+
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	response, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	responseBody, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("unable to read listenbrainz following response")
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, parseListenBrainzError(response.StatusCode, responseBody, "listenbrainz following lookup failed")
+	}
+
+	parsedResponse := listenBrainzFollowingResponse{}
+	if err := json.Unmarshal(responseBody, &parsedResponse); err != nil {
+		return nil, errors.New("invalid listenbrainz following response")
+	}
+
+	following := make([]string, 0, len(parsedResponse.Following))
+	for _, rawUserName := range parsedResponse.Following {
+		trimmedUserName := strings.TrimSpace(rawUserName)
+		if trimmedUserName == "" {
+			continue
+		}
+
+		following = append(following, trimmedUserName)
+	}
+
+	return following, nil
+}
+
+// GetListenBrainzFollowingFeed fetches recent listen events for the configured account's followed users.
+func (a *App) GetListenBrainzFollowingFeed(count int) ([]ListenBrainzSocialEvent, error) {
+	token, err := a.listenBrainzToken()
+	if err != nil {
+		return nil, err
+	}
+
+	userName, err := a.listenBrainzUserName(token)
+	if err != nil {
+		return nil, err
+	}
+
+	requestURL := fmt.Sprintf(
+		a.listenBrainzServerURL()+listenBrainzFeedEventsFollowingPath,
+		url.PathEscape(userName),
+	)
+
+	query := url.Values{}
+	query.Set("count", fmt.Sprintf("%d", normalizeListenBrainzSocialCount(count)))
+	requestURL = requestURL + "?" + query.Encode()
+
+	a.waitForListenBrainzRequestSlotIfNeeded()
+
+	httpRequest, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpRequest.Header.Set("Accept", "application/json")
+	httpRequest.Header.Set("Authorization", fmt.Sprintf("Token %s", token))
+
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	response, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	responseBody, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("unable to read listenbrainz following feed response")
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, parseListenBrainzError(response.StatusCode, responseBody, "listenbrainz following feed lookup failed")
+	}
+
+	parsedResponse := listenBrainzSocialFeedResponse{}
+	if err := json.Unmarshal(responseBody, &parsedResponse); err != nil {
+		return nil, errors.New("invalid listenbrainz following feed response")
+	}
+
+	events := make([]ListenBrainzSocialEvent, 0, len(parsedResponse.Payload.Events))
+	for _, event := range parsedResponse.Payload.Events {
+		mappedEvent := ListenBrainzSocialEvent{
+			ID:            event.ID,
+			Created:       event.Created,
+			EventType:     strings.TrimSpace(event.EventType),
+			Hidden:        event.Hidden,
+			Message:       strings.TrimSpace(event.Message),
+			UserName:      strings.TrimSpace(event.UserName),
+			ListenedAt:    event.Metadata.ListenedAt,
+			ListenedAtISO: strings.TrimSpace(event.Metadata.ListenedAtISO),
+			PlayingNow:    event.Metadata.PlayingNow,
+			TrackMetadata: ListenBrainzSocialTrackMetadata{
+				ArtistName:  strings.TrimSpace(event.Metadata.TrackMetadata.ArtistName),
+				TrackName:   strings.TrimSpace(event.Metadata.TrackMetadata.TrackName),
+				ReleaseName: strings.TrimSpace(event.Metadata.TrackMetadata.ReleaseName),
+				AdditionalInfo: ListenBrainzSocialAdditionalInfo{
+					RecordingMBID:    strings.TrimSpace(event.Metadata.TrackMetadata.AdditionalInfo.RecordingMBID),
+					RecordingMSID:    strings.TrimSpace(event.Metadata.TrackMetadata.AdditionalInfo.RecordingMSID),
+					ReleaseMBID:      strings.TrimSpace(event.Metadata.TrackMetadata.AdditionalInfo.ReleaseMBID),
+					ReleaseGroupMBID: strings.TrimSpace(event.Metadata.TrackMetadata.AdditionalInfo.ReleaseGroupMBID),
+					ArtistMBIDs:      event.Metadata.TrackMetadata.AdditionalInfo.ArtistMBIDs,
+					OriginURL:        strings.TrimSpace(event.Metadata.TrackMetadata.AdditionalInfo.OriginURL),
+					MusicService:     strings.TrimSpace(event.Metadata.TrackMetadata.AdditionalInfo.MusicService),
+					MusicServiceName: strings.TrimSpace(event.Metadata.TrackMetadata.AdditionalInfo.MusicServiceName),
+					DurationMs:       event.Metadata.TrackMetadata.AdditionalInfo.DurationMs,
+				},
+			},
+		}
+
+		if mappedEvent.UserName == "" {
+			mappedEvent.UserName = strings.TrimSpace(event.Metadata.UserName)
+		}
+		if mappedEvent.Created <= 0 {
+			mappedEvent.Created = event.Metadata.Created
+		}
+		if mappedEvent.Created <= 0 {
+			mappedEvent.Created = event.Metadata.InsertedAt
+		}
+		if mappedEvent.Created <= 0 {
+			mappedEvent.Created = mappedEvent.ListenedAt
+		}
+
+		events = append(events, mappedEvent)
+	}
+
+	return events, nil
 }

--- a/listenbrainz_social_test.go
+++ b/listenbrainz_social_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetListenBrainzFollowingAndFeed(t *testing.T) {
+	listenBrainzUserNameCacheMu.Lock()
+	listenBrainzUserNameCache = map[string]string{}
+	listenBrainzUserNameCacheMu.Unlock()
+
+	const token = "secret-token"
+	const userName = "tester"
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "Token "+token {
+			t.Fatalf("Authorization header = %q, want %q", request.Header.Get("Authorization"), "Token "+token)
+		}
+
+		switch request.URL.Path {
+		case "/1/validate-token":
+			writer.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(writer).Encode(map[string]any{
+				"valid":     true,
+				"user_name": userName,
+			})
+		case "/1/user/tester/following":
+			writer.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(writer).Encode(map[string]any{
+				"following": []string{"alice", " bob ", ""},
+				"user":      userName,
+			})
+		case "/1/user/tester/feed/events/listens/following":
+			if request.URL.Query().Get("count") != "25" {
+				t.Fatalf("count query = %q, want %q", request.URL.Query().Get("count"), "25")
+			}
+
+			writer.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(writer).Encode(map[string]any{
+				"payload": map[string]any{
+					"count":   1,
+					"user_id": "test-user-id",
+					"events": []map[string]any{{
+						"created":    1710000100,
+						"event_type": "listen",
+						"hidden":     false,
+						"id":         7,
+						"message":    "",
+						"user_name":  "alice",
+						"metadata": map[string]any{
+							"listened_at":     1710000000,
+							"listened_at_iso": "2024-03-09T16:00:00Z",
+							"playing_now":     true,
+							"track_metadata": map[string]any{
+								"artist_name":  "Artist One",
+								"track_name":   "Track One",
+								"release_name": "Album One",
+								"additional_info": map[string]any{
+									"recording_mbid":     "11111111-1111-1111-1111-111111111111",
+									"recording_msid":     "22222222-2222-2222-2222-222222222222",
+									"release_mbid":       "33333333-3333-3333-3333-333333333333",
+									"release_group_mbid": "44444444-4444-4444-4444-444444444444",
+									"artist_mbids":       []string{"55555555-5555-5555-5555-555555555555"},
+									"origin_url":         "https://example.com/track-one",
+									"music_service":      "spotify.com",
+									"music_service_name": "Spotify",
+									"duration_ms":        245000,
+								},
+							},
+						},
+					}},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request path %q", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	app := &App{
+		settings: AppSettings{
+			ListenBrainzUserToken:     token,
+			ListenBrainzServerURL:     server.URL,
+			ListenBrainzRequestRateMs: 0,
+		},
+		settingsLoaded: true,
+	}
+
+	following, err := app.GetListenBrainzFollowing()
+	if err != nil {
+		t.Fatalf("GetListenBrainzFollowing() error = %v", err)
+	}
+
+	if len(following) != 2 {
+		t.Fatalf("len(GetListenBrainzFollowing()) = %d, want %d", len(following), 2)
+	}
+	if following[0] != "alice" || following[1] != "bob" {
+		t.Fatalf("GetListenBrainzFollowing() = %#v, want %#v", following, []string{"alice", "bob"})
+	}
+
+	events, err := app.GetListenBrainzFollowingFeed(0)
+	if err != nil {
+		t.Fatalf("GetListenBrainzFollowingFeed() error = %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("len(GetListenBrainzFollowingFeed()) = %d, want %d", len(events), 1)
+	}
+
+	event := events[0]
+	if event.ID != 7 {
+		t.Fatalf("event.ID = %d, want %d", event.ID, 7)
+	}
+	if event.UserName != "alice" {
+		t.Fatalf("event.UserName = %q, want %q", event.UserName, "alice")
+	}
+	if event.ListenedAt != 1710000000 {
+		t.Fatalf("event.ListenedAt = %d, want %d", event.ListenedAt, 1710000000)
+	}
+	if !event.PlayingNow {
+		t.Fatalf("event.PlayingNow = %t, want %t", event.PlayingNow, true)
+	}
+	if event.TrackMetadata.TrackName != "Track One" {
+		t.Fatalf("event.TrackMetadata.TrackName = %q, want %q", event.TrackMetadata.TrackName, "Track One")
+	}
+	if event.TrackMetadata.ArtistName != "Artist One" {
+		t.Fatalf("event.TrackMetadata.ArtistName = %q, want %q", event.TrackMetadata.ArtistName, "Artist One")
+	}
+	if event.TrackMetadata.ReleaseName != "Album One" {
+		t.Fatalf("event.TrackMetadata.ReleaseName = %q, want %q", event.TrackMetadata.ReleaseName, "Album One")
+	}
+	if event.TrackMetadata.AdditionalInfo.MusicServiceName != "Spotify" {
+		t.Fatalf("event.TrackMetadata.AdditionalInfo.MusicServiceName = %q, want %q", event.TrackMetadata.AdditionalInfo.MusicServiceName, "Spotify")
+	}
+	if event.TrackMetadata.AdditionalInfo.OriginURL != "https://example.com/track-one" {
+		t.Fatalf("event.TrackMetadata.AdditionalInfo.OriginURL = %q, want %q", event.TrackMetadata.AdditionalInfo.OriginURL, "https://example.com/track-one")
+	}
+}


### PR DESCRIPTION
Adds a new Social section to the sidebar so users can switch between Library and Social from a dropdown in the sidebar header. The Social view shows recent ListenBrainz activity from followed users, keeps only the latest scrobble per user, and updates automatically via silent polling.

The update also improves UX with:
- Smooth animation when switching between Library and Social sections
- Animated feed updates when new scrobbles arrive
- ListenBrainz icon shown next to each username
- Cleaner Social UI (no manual refresh button, no polling status noise)

Resolves #13.