### PR TITLE
Refine Last.fm integration and social feed UX

### DIFF
--- a/app.go
+++ b/app.go
@@ -85,6 +85,8 @@ type App struct {
 	scanFinalizeMs                         float64
 	scanWatcherMs                          float64
 	searchGeneration                       atomic.Uint64
+	lastFmScrobbleMu                       sync.Mutex
+	lastFmRecentScrobbles                  map[string]lastFmScrobbleDedupEntry
 }
 
 // NewApp creates a new App application struct

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -549,6 +549,28 @@
     text-align: left;
 }
 
+.social-feed-user-link {
+    border: 0;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 255, 255, 0.35);
+    text-underline-offset: 0.12rem;
+}
+
+.social-feed-user-link:hover,
+.social-feed-user-link:focus-visible {
+    color: rgba(255, 255, 255, 1);
+    text-decoration-color: rgba(255, 255, 255, 0.85);
+}
+
+.social-feed-user-link:focus-visible {
+    outline: 1px solid rgba(255, 255, 255, 0.5);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
 .social-feed-verb {
     margin-top: 0.12rem;
     font-size: 0.73rem;
@@ -579,35 +601,6 @@
     font-size: 0.82rem;
     line-height: 1.35;
     color: rgba(255, 255, 255, 0.72);
-}
-
-.social-feed-badges {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    margin-top: 0.7rem;
-}
-
-.social-feed-badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 999px;
-    padding: 0.22rem 0.5rem;
-    font-size: 0.7rem;
-    line-height: 1;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.86);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    background: rgba(255, 255, 255, 0.05);
-}
-
-.social-feed-badge.is-live {
-    color: rgba(180, 255, 220, 0.96);
-    border-color: rgba(116, 214, 170, 0.28);
-    background: rgba(116, 214, 170, 0.12);
 }
 
 .social-feed-empty {

--- a/frontend/src/components/overlays/overlays.css
+++ b/frontend/src/components/overlays/overlays.css
@@ -1141,6 +1141,13 @@
     gap: 0.45rem;
 }
 
+.settings-lastfm-session-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.45rem;
+}
+
 .settings-server-url-row {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;

--- a/frontend/src/components/overlays/settings-modal.ts
+++ b/frontend/src/components/overlays/settings-modal.ts
@@ -53,6 +53,10 @@ export type SettingsModalElements = {
     settingsScrobbleRuleConfirm: HTMLButtonElement;
     settingsFFmpegPath: HTMLInputElement;
     settingsListenBrainzToken: HTMLInputElement;
+    settingsLastFmApiKey: HTMLInputElement;
+    settingsLastFmApiSecret: HTMLInputElement;
+    settingsLastFmSessionKey: HTMLInputElement;
+    settingsLastFmSessionKeyFetch: HTMLButtonElement;
     settingsMusicBrainzServerUrl: HTMLInputElement;
     settingsMusicBrainzRequestRateMs: HTMLInputElement;
     settingsListenBrainzServerUrl: HTMLInputElement;
@@ -140,6 +144,24 @@ export const renderSettingsModal = (): string => `
                         <input id="settings-listenbrainz-token" class="settings-input" type="password" placeholder="Optional">
                     </div>
                     <div class="settings-field">
+                        <label class="settings-label" for="settings-lastfm-api-key">Last.fm API key</label>
+                        <p class="settings-hint">Optional. When the API key, shared secret, and session key are all set, allowed scrobbles are also submitted to Last.fm.</p>
+                        <input id="settings-lastfm-api-key" class="settings-input" type="text" spellcheck="false" placeholder="Optional">
+                    </div>
+                    <div class="settings-field">
+                        <label class="settings-label" for="settings-lastfm-api-secret">Last.fm shared secret</label>
+                        <p class="settings-hint">Used to sign Last.fm write requests. Pair it with your own API key and desktop-auth session key.</p>
+                        <input id="settings-lastfm-api-secret" class="settings-input" type="password" spellcheck="false" placeholder="Optional">
+                    </div>
+                    <div class="settings-field">
+                        <label class="settings-label" for="settings-lastfm-session-key">Last.fm session key</label>
+                        <p class="settings-hint">Session keys are obtained through the Last.fm desktop authentication flow and remain valid until revoked.</p>
+                        <div class="settings-lastfm-session-row">
+                            <input id="settings-lastfm-session-key" class="settings-input" type="password" spellcheck="false" placeholder="Optional">
+                            <button id="settings-lastfm-session-key-fetch" class="settings-secondary-btn" type="button">Fetch</button>
+                        </div>
+                    </div>
+                    <div class="settings-field">
                         <label class="settings-label" for="settings-musicbrainz-server-url">MusicBrainz server URL</label>
                         <p class="settings-hint">Override the MusicBrainz server used for lookups. Local hosts are permitted a shorter cooldown between requests.</p>
                         <div class="settings-server-url-row">
@@ -216,7 +238,7 @@ export const renderSettingsModal = (): string => `
                 <div id="settings-panel-scrobbling" class="settings-panel" role="tabpanel" aria-labelledby="settings-tab-scrobbling" hidden>
                     <div class="settings-field">
                         <label class="settings-label" for="settings-scrobble-filter-mode">Scrobble mode</label>
-                        <p class="settings-hint">In blacklist mode matching rules block scrobbles. In whitelist mode at least one rule must match before a scrobble is submitted.</p>
+                        <p class="settings-hint">In blacklist mode matching rules block scrobbles. In whitelist mode at least one rule must match before a scrobble is submitted. The same rules apply to every configured scrobble provider.</p>
                         <select id="settings-scrobble-filter-mode" class="settings-input settings-select">
                             <option value="blacklist">Blacklist: scrobble unless a rule matches</option>
                             <option value="whitelist">Whitelist: scrobble only when a rule matches</option>
@@ -429,6 +451,10 @@ export const getSettingsModalElements = (root: ParentNode): SettingsModalElement
     settingsScrobbleRuleConfirm: root.querySelector('#settings-scrobble-rule-confirm') as HTMLButtonElement,
     settingsFFmpegPath: root.querySelector('#settings-ffmpeg-path') as HTMLInputElement,
     settingsListenBrainzToken: root.querySelector('#settings-listenbrainz-token') as HTMLInputElement,
+    settingsLastFmApiKey: root.querySelector('#settings-lastfm-api-key') as HTMLInputElement,
+    settingsLastFmApiSecret: root.querySelector('#settings-lastfm-api-secret') as HTMLInputElement,
+    settingsLastFmSessionKey: root.querySelector('#settings-lastfm-session-key') as HTMLInputElement,
+    settingsLastFmSessionKeyFetch: root.querySelector('#settings-lastfm-session-key-fetch') as HTMLButtonElement,
     settingsMusicBrainzServerUrl: root.querySelector('#settings-musicbrainz-server-url') as HTMLInputElement,
     settingsMusicBrainzRequestRateMs: root.querySelector('#settings-musicbrainz-request-rate-ms') as HTMLInputElement,
     settingsListenBrainzServerUrl: root.querySelector('#settings-listenbrainz-server-url') as HTMLInputElement,

--- a/frontend/src/controllers/listenbrainz-social-controller.test.ts
+++ b/frontend/src/controllers/listenbrainz-social-controller.test.ts
@@ -30,9 +30,11 @@ const flushPromises = async (): Promise<void> => {
 
 const mountController = (options?: {
     token?: string;
+    hasAnyProviderConfigured?: boolean;
     isSidebarVisible?: () => boolean;
     fetchFollowingUsers?: () => Promise<string[]>;
     fetchFollowingFeed?: (count: number) => Promise<ListenBrainzSocialEvent[]>;
+    openUserProfile?: (provider: 'listenbrainz' | 'lastfm', userName: string) => void | Promise<void>;
 }) => {
     document.body.innerHTML = `
         <button id="sidebar-toggle" type="button"></button>
@@ -60,6 +62,7 @@ const mountController = (options?: {
 
     const fetchFollowingUsers = options?.fetchFollowingUsers || vi.fn(async () => ['alice', 'bob']);
     const fetchFollowingFeed = options?.fetchFollowingFeed || vi.fn(async () => [createEvent()]);
+    const openUserProfile = options?.openUserProfile || vi.fn();
 
     const controller = createListenBrainzSocialController({
         elements: {
@@ -74,10 +77,11 @@ const mountController = (options?: {
             socialFeedStatus,
             socialFeedList,
         },
-        getToken: () => options?.token ?? 'token',
+        hasAnyProviderConfigured: () => options?.hasAnyProviderConfigured ?? (options?.token ?? 'token').trim() !== '',
         isSidebarVisible: options?.isSidebarVisible || (() => true),
         fetchFollowingUsers,
         fetchFollowingFeed,
+        openUserProfile,
     });
 
     return {
@@ -93,6 +97,7 @@ const mountController = (options?: {
         socialFeedList,
         fetchFollowingUsers,
         fetchFollowingFeed,
+        openUserProfile,
     };
 };
 
@@ -178,20 +183,20 @@ describe('createListenBrainzSocialController', () => {
         expect(socialFeedList.textContent).toContain('bob');
     });
 
-    it('shows a token-required empty state when ListenBrainz is not configured', async () => {
+    it('shows an account-required empty state when no social provider is configured', async () => {
         const {
             sidebarSectionOptionSocial,
             socialFeedList,
             fetchFollowingUsers,
             fetchFollowingFeed,
-        } = mountController({ token: '' });
+        } = mountController({ hasAnyProviderConfigured: false });
 
         sidebarSectionOptionSocial.click();
         await flushPromises();
 
         expect(fetchFollowingUsers).not.toHaveBeenCalled();
         expect(fetchFollowingFeed).not.toHaveBeenCalled();
-        expect(socialFeedList.textContent).toContain('ListenBrainz token required');
+        expect(socialFeedList.textContent).toContain('Social account required');
     });
 
     it('polls again while the social tab stays active', async () => {
@@ -209,10 +214,10 @@ describe('createListenBrainzSocialController', () => {
     });
 
     it('keeps background polling silent once the feed has loaded', async () => {
-        let resolveSecondFeedRequest: ((events: ListenBrainzSocialEvent[]) => void) | null = null;
-        const fetchFollowingFeed = vi.fn<() => Promise<ListenBrainzSocialEvent[]>>()
+        let resolveSecondFeedRequest: (events: ListenBrainzSocialEvent[]) => void = () => undefined;
+        const fetchFollowingFeed = vi.fn<[count: number], Promise<ListenBrainzSocialEvent[]>>()
             .mockResolvedValueOnce([createEvent()])
-            .mockImplementationOnce(async () => await new Promise<ListenBrainzSocialEvent[]>((resolve) => {
+            .mockImplementationOnce(async (_count: number) => await new Promise<ListenBrainzSocialEvent[]>((resolve) => {
                 resolveSecondFeedRequest = resolve;
             }));
         const { sidebarSectionOptionSocial, socialFeedStatus } = mountController({ fetchFollowingFeed });
@@ -230,7 +235,7 @@ describe('createListenBrainzSocialController', () => {
         expect(fetchFollowingFeed).toHaveBeenCalledTimes(2);
         expect(socialFeedStatus.textContent).toBe('');
 
-        resolveSecondFeedRequest?.([createEvent({ id: 2, trackMetadata: {
+        resolveSecondFeedRequest([createEvent({ id: 2, trackMetadata: {
             artistName: 'Artist Two',
             trackName: 'Track Two',
             releaseName: 'Album Two',
@@ -292,5 +297,41 @@ describe('createListenBrainzSocialController', () => {
         expect(sidebarPaneLibrary.hidden).toBe(false);
         expect(sidebarPaneSocial.hidden).toBe(true);
         expect(controller.isSocialActive()).toBe(false);
+    });
+
+    it('opens the user profile when a username is clicked', async () => {
+        const openUserProfile = vi.fn();
+        const {
+            sidebarSectionOptionSocial,
+            socialFeedList,
+        } = mountController({
+            openUserProfile,
+            fetchFollowingFeed: vi.fn(async () => [
+                createEvent({
+                    userName: 'lastfm-user',
+                    trackMetadata: {
+                        artistName: 'Artist One',
+                        trackName: 'Track One',
+                        releaseName: 'Album One',
+                        additionalInfo: {
+                            musicServiceName: 'Last.fm',
+                        },
+                    },
+                }),
+            ]),
+        });
+
+        sidebarSectionOptionSocial.click();
+        await flushPromises();
+
+        await vi.waitFor(() => {
+            expect(socialFeedList.textContent).toContain('lastfm-user');
+        });
+
+        const userButton = socialFeedList.querySelector('[data-social-user-name="lastfm-user"]') as HTMLButtonElement | null;
+        expect(userButton).not.toBeNull();
+        userButton?.click();
+
+        expect(openUserProfile).toHaveBeenCalledWith('lastfm', 'lastfm-user');
     });
 });

--- a/frontend/src/controllers/listenbrainz-social-controller.ts
+++ b/frontend/src/controllers/listenbrainz-social-controller.ts
@@ -5,10 +5,11 @@ type SidebarSection = 'library' | 'social';
 
 type ListenBrainzSocialControllerOptions = {
     elements: Pick<SidebarElements, 'sidebarToggle' | 'sidebarSectionTrigger' | 'sidebarSectionTriggerLabel' | 'sidebarSectionMenu' | 'sidebarSectionOptionLibrary' | 'sidebarSectionOptionSocial' | 'sidebarPaneLibrary' | 'sidebarPaneSocial' | 'socialFeedStatus' | 'socialFeedList'>;
-    getToken: () => string;
+    hasAnyProviderConfigured: () => boolean;
     isSidebarVisible: () => boolean;
     fetchFollowingUsers: () => Promise<string[]>;
     fetchFollowingFeed: (count: number) => Promise<ListenBrainzSocialEvent[]>;
+    openUserProfile: (provider: 'listenbrainz' | 'lastfm', userName: string) => void | Promise<void>;
 };
 
 export type ListenBrainzSocialController = ReturnType<typeof createListenBrainzSocialController>;
@@ -19,6 +20,7 @@ const socialFeedUpdateAnimationMs = 420;
 const sidebarSectionSwitchAnimationMs = 240;
 
 const listenBrainzUserIcon = '<svg class="social-feed-listenbrainz-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 27 30" aria-hidden="true"><polygon fill="#353070" points="13 1 1 8 1 22 13 29 13 1"/><polygon fill="#eb743b" points="14 1 26 8 26 22 14 29 14 1"/></svg>';
+const lastFmUserIcon = '<svg class="social-feed-lastfm-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" aria-hidden="true"><g fill-rule="evenodd"><path fill="#fbfbfb" d="M125.78 125.25c-41.65 3.9-63.03 30.12-63.04 77.29-.01 32.45 10.87 53.98 32.86 65.02 22.61 11.35 60.18 9.34 81.94-4.38 3.1-1.96 6.05-4.25 6.05-4.7 0-.58-9.43-25.78-9.8-26.21-.17-.2-1.5.75-2.97 2.1-16.9 15.53-42.34 19.7-57.31 9.4-23.15-15.92-24.22-67.89-1.8-86.25 12.84-10.5 35.78-10.24 48.64.56 8.78 7.37 12.06 14.01 22.47 45.44 8.7 26.26 9.88 29.26 14.56 37.1 14.13 23.7 37.01 34.16 74.69 34.16 42.82 0 64.06-13.2 65.32-40.6.9-19.63-8.18-33.79-26.52-41.36-6.48-2.68-11.19-3.95-27.67-7.48-20.7-4.43-25.12-7.8-25.17-19.15-.05-11.28 7.3-16.78 22.44-16.77 14.42 0 21.45 4.56 23.73 15.35.34 1.65.66 3.05.69 3.1.08.13 30.3-3.4 30.93-3.61 1.99-.67-2.52-14.97-6.65-21.1-15.13-22.46-69.3-24.98-91.27-4.25-14.75 13.92-16.12 41.79-2.78 56.86 6.7 7.58 14.98 11.11 39.28 16.74 23.68 5.49 28.99 8.68 30.7 18.5 2.18 12.54-7.9 18.62-31.08 18.74-23.64.12-37.71-7.03-47.62-24.2-2.97-5.15-4.58-9.31-11.6-30.15-13-38.55-19.06-48.99-34.33-59.13-12.3-8.18-35.42-12.84-54.69-11.03"/><path fill="#e41c24" d="M66.8.63A78.3 78.3 0 0 0 .6 67.23c-.91 6.3-.91 259.23 0 265.53a78.2 78.2 0 0 0 66.64 66.64c6.3.91 259.22.91 265.52 0a78.2 78.2 0 0 0 66.64-66.64c.91-6.3.91-259.22 0-265.52A78.2 78.2 0 0 0 332.76.6C326.72-.27 72.61-.24 66.8.63m83.6 125.35c24.92 3.4 40.14 13.76 51.3 34.96 3.32 6.3 5.84 12.94 13.1 34.46 7.02 20.84 8.63 25 11.6 30.15 9.9 17.16 23.98 24.32 47.62 24.2 23.18-.12 33.26-6.2 31.08-18.74-1.71-9.82-7.02-13.01-30.7-18.5-18.13-4.2-22.87-5.68-29.09-9.07-13.86-7.57-19.58-18.43-19.04-36.13.84-27.23 20.8-42.33 55.96-42.3 30.85.01 48.87 11.25 53.06 33.08.95 4.95 1.04 6 .53 6.17-.62.2-30.85 3.74-30.93 3.61-.03-.05-.35-1.45-.7-3.1-2.26-10.79-9.3-15.34-23.72-15.35-15.14-.01-22.5 5.49-22.44 16.77.05 11.35 4.47 14.72 25.17 19.15 16.48 3.53 21.2 4.8 27.67 7.48 18.34 7.57 27.42 21.73 26.52 41.36-1.26 27.4-22.5 40.6-65.32 40.6-37.68 0-60.56-10.46-74.69-34.15-4.68-7.85-5.86-10.85-14.56-37.11-10.4-31.43-13.7-38.07-22.47-45.44-12.86-10.8-35.8-11.07-48.63-.56-22.43 18.36-21.36 70.33 1.79 86.25 14.97 10.3 40.41 6.13 57.31-9.4 1.47-1.35 2.8-2.3 2.97-2.1.37.43 9.8 25.63 9.8 26.2 0 .46-2.95 2.75-6.05 4.7-21.76 13.73-59.33 15.74-81.94 4.39-21.99-11.04-32.87-32.57-32.86-65.02 0-47.17 21.39-73.38 63.04-77.3 3.73-.35 20.27.15 24.61.74"/></g></svg>';
 
 const escapeHtml = (value: string): string => value
     .replaceAll('&', '&amp;')
@@ -27,20 +29,19 @@ const escapeHtml = (value: string): string => value
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
 
-const formatMusicServiceLabel = (event: ListenBrainzSocialEvent): string => {
-    const explicitName = (event.trackMetadata.additionalInfo.musicServiceName || '').trim();
-    if (explicitName !== '') {
-        return explicitName;
+const socialEventProvider = (event: ListenBrainzSocialEvent): 'listenbrainz' | 'lastfm' => {
+    const explicitName = (event.trackMetadata.additionalInfo.musicServiceName || '').trim().toLowerCase();
+    if (explicitName === 'last.fm' || explicitName === 'lastfm') {
+        return 'lastfm';
     }
 
-    const domain = (event.trackMetadata.additionalInfo.musicService || '').trim().toLowerCase();
-    if (domain === '') {
-        return '';
+    const serviceDomain = (event.trackMetadata.additionalInfo.musicService || '').trim().toLowerCase();
+    if (serviceDomain === 'last.fm' || serviceDomain === 'lastfm' || serviceDomain.includes('last.fm')) {
+        return 'lastfm';
     }
 
-    return domain.replace(/^www\./, '').replace(/\.[a-z0-9]+$/, '');
+    return 'listenbrainz';
 };
-
 const formatRelativeTime = (timestampSeconds: number): string => {
     if (!Number.isFinite(timestampSeconds) || timestampSeconds <= 0) {
         return 'just now';
@@ -237,17 +238,17 @@ export const createListenBrainzSocialController = (options: ListenBrainzSocialCo
 
     const renderEvents = (): string => {
         if (socialEvents.length === 0) {
-            if (options.getToken().trim() === '') {
+            if (!options.hasAnyProviderConfigured()) {
                 return renderEmptyState(
-                    'ListenBrainz token required',
-                    'Add your ListenBrainz user token in Settings to load the people you follow and their recent scrobbles.',
+                    'Social account required',
+                    'Add your ListenBrainz token or Last.fm credentials in Settings to load the people you follow and their recent scrobbles.',
                 );
             }
 
             if (followingUsers.length === 0) {
                 return renderEmptyState(
                     'No followed users yet',
-                    'This view reads your ListenBrainz following feed. Follow a few people there and their new scrobbles will appear here.',
+                    'This view reads your ListenBrainz and Last.fm following feeds. Follow a few people there and their scrobbles will appear here.',
                 );
             }
 
@@ -266,25 +267,19 @@ export const createListenBrainzSocialController = (options: ListenBrainzSocialCo
             const trackName = (event.trackMetadata.trackName || '').trim() || 'Unknown track';
             const artistName = (event.trackMetadata.artistName || '').trim() || 'Unknown artist';
             const releaseName = (event.trackMetadata.releaseName || '').trim();
-            const serviceLabel = formatMusicServiceLabel(event);
             const secondaryLine = releaseName !== ''
                 ? `${artistName} • ${releaseName}`
                 : artistName;
-            const badges: string[] = [];
-            if (event.playingNow) {
-                badges.push('<span class="social-feed-badge is-live">Live</span>');
-            }
-            if (serviceLabel !== '') {
-                badges.push(`<span class="social-feed-badge">${escapeHtml(serviceLabel)}</span>`);
-            }
+            const provider = socialEventProvider(event);
+            const iconMarkup = provider === 'lastfm' ? lastFmUserIcon : listenBrainzUserIcon;
 
             return `
                 <article class="social-feed-card${event.playingNow ? ' is-live' : ''}">
                     <div class="social-feed-card-header">
                         <div class="social-feed-identity">
-                            <span class="social-feed-avatar" aria-hidden="true">${listenBrainzUserIcon}</span>
+                            <span class="social-feed-avatar" aria-hidden="true">${iconMarkup}</span>
                             <div class="social-feed-user-copy">
-                                <p class="social-feed-user">${escapeHtml((event.userName || '').trim() || 'Unknown user')}</p>
+                                <button class="social-feed-user social-feed-user-link" type="button" data-social-user-name="${escapeHtml((event.userName || '').trim())}" data-social-user-provider="${provider}">${escapeHtml((event.userName || '').trim() || 'Unknown user')}</button>
                                 <p class="social-feed-verb">${event.playingNow ? 'is listening now' : 'scrobbled recently'}</p>
                             </div>
                         </div>
@@ -292,7 +287,6 @@ export const createListenBrainzSocialController = (options: ListenBrainzSocialCo
                     </div>
                     <p class="social-feed-track">${escapeHtml(trackName)}</p>
                     <p class="social-feed-meta">${escapeHtml(secondaryLine)}</p>
-                    ${badges.length > 0 ? `<div class="social-feed-badges">${badges.join('')}</div>` : ''}
                 </article>
             `;
         }).join('');
@@ -333,7 +327,7 @@ export const createListenBrainzSocialController = (options: ListenBrainzSocialCo
 
     const scheduleNextPoll = (): void => {
         stopPolling();
-        if (activeSection !== 'social' || options.getToken().trim() === '' || !options.isSidebarVisible()) {
+        if (activeSection !== 'social' || !options.hasAnyProviderConfigured() || !options.isSidebarVisible()) {
             return;
         }
 
@@ -349,8 +343,7 @@ export const createListenBrainzSocialController = (options: ListenBrainzSocialCo
             return;
         }
 
-        const token = options.getToken().trim();
-        if (token === '') {
+        if (!options.hasAnyProviderConfigured()) {
             followingUsers = [];
             socialEvents = [];
             lastErrorMessage = '';
@@ -415,7 +408,7 @@ export const createListenBrainzSocialController = (options: ListenBrainzSocialCo
     };
 
     const handleSettingsChanged = (): void => {
-        if (options.getToken().trim() === '') {
+        if (!options.hasAnyProviderConfigured()) {
             followingUsers = [];
             socialEvents = [];
             lastErrorMessage = '';
@@ -441,6 +434,25 @@ export const createListenBrainzSocialController = (options: ListenBrainzSocialCo
     });
     sidebarSectionOptionLibrary.addEventListener('click', showLibrary);
     sidebarSectionOptionSocial.addEventListener('click', showSocial);
+    socialFeedList.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) {
+            return;
+        }
+
+        const userButton = target.closest('[data-social-user-name][data-social-user-provider]');
+        if (!(userButton instanceof HTMLButtonElement)) {
+            return;
+        }
+
+        const userName = (userButton.dataset.socialUserName || '').trim();
+        const provider = userButton.dataset.socialUserProvider;
+        if (userName === '' || (provider !== 'listenbrainz' && provider !== 'lastfm')) {
+            return;
+        }
+
+        void options.openUserProfile(provider, userName);
+    });
     document.addEventListener('click', (event) => {
         if (!sectionMenuOpen) {
             return;

--- a/frontend/src/controllers/settings-controller.test.ts
+++ b/frontend/src/controllers/settings-controller.test.ts
@@ -38,6 +38,9 @@ const createSettingsViewValues = (): SettingsViewValues => ({
     libraryFolders: [{ path: '/music/main', label: 'Main Library', releaseDepth: 2 }],
     ffmpegPath: '',
     listenBrainzUserToken: '',
+    lastFmApiKey: '',
+    lastFmApiSecret: '',
+    lastFmSessionKey: '',
     scrobbleFilterMode: 'blacklist',
     scrobbleRules: [{ field: 'path', operator: 'starts_with', value: '/music/private' }],
     musicBrainzServerUrl: 'https://musicbrainz.org',
@@ -65,6 +68,7 @@ const mountSettingsController = (options: {
     getValues?: () => SettingsViewValues;
     save?: (values: SettingsFormValues) => Promise<void>;
     forceReload?: (values: SettingsFormValues) => Promise<void>;
+    fetchLastFmSessionKey?: (apiKey: string, apiSecret: string) => Promise<string>;
 } = {}) => {
     document.body.innerHTML = renderSettingsModal();
     const trigger = document.createElement('button');
@@ -73,6 +77,7 @@ const mountSettingsController = (options: {
     const elements = getSettingsModalElements(document);
     const save = options.save ?? vi.fn(async () => undefined);
     const forceReload = options.forceReload ?? vi.fn(async () => undefined);
+    const fetchLastFmSessionKey = options.fetchLastFmSessionKey ?? vi.fn(async () => 'session-key');
     const applyAudioNow = vi.fn(async () => createAudioDevices());
     const setPlayerCardLayout = vi.fn((_layout: PlayerCardLayout) => undefined);
 
@@ -83,6 +88,7 @@ const mountSettingsController = (options: {
         selectLibraryFolder: vi.fn(async () => ''),
         selectPlaylistFile: vi.fn(async () => ''),
         save,
+        fetchLastFmSessionKey,
         applyAudioNow,
         forceReload,
         getPlayerCardLayout: () => 'release',
@@ -94,6 +100,7 @@ const mountSettingsController = (options: {
         elements,
         save,
         forceReload,
+        fetchLastFmSessionKey,
     };
 };
 
@@ -130,6 +137,10 @@ describe('createSettingsController', () => {
         expect(document.querySelector('label[for="settings-library-folder-list"]')?.textContent).toBe('Library folders');
         expect(document.querySelector('label[for="settings-ffmpeg-path"]')?.textContent).toBe('FFmpeg executable path');
         expect(document.querySelector('label[for="settings-listenbrainz-token"]')?.textContent).toBe('ListenBrainz user token');
+        expect(document.querySelector('label[for="settings-lastfm-api-key"]')?.textContent).toBe('Last.fm API key');
+        expect(document.querySelector('label[for="settings-lastfm-api-secret"]')?.textContent).toBe('Last.fm shared secret');
+        expect(document.querySelector('label[for="settings-lastfm-session-key"]')?.textContent).toBe('Last.fm session key');
+        expect(document.querySelector('#settings-lastfm-session-key-fetch')?.textContent).toBe('Fetch');
         expect(document.querySelector('label[for="settings-musicbrainz-server-url"]')?.textContent).toBe('MusicBrainz server URL');
         expect(document.querySelector('label[for="settings-listenbrainz-server-url"]')?.textContent).toBe('ListenBrainz server URL');
         expect(document.querySelector('label[for="settings-musicbrainz-tag-worker-cores"]')?.textContent).toBe('MusicBrainz tag worker cores');
@@ -194,6 +205,23 @@ describe('createSettingsController', () => {
             keyboardShortcuts: expect.objectContaining({ nextTrack: 'K' }),
         }));
         expect(elements.settingsModal.classList.contains('is-visible')).toBe(false);
+    });
+
+    it('fetches Last.fm session key and fills the field', async () => {
+        const fetchLastFmSessionKey = vi.fn(async () => 'session-key-from-fetch');
+        const { controller, elements } = mountSettingsController({ fetchLastFmSessionKey });
+
+        controller.open('network');
+
+        elements.settingsLastFmApiKey.value = 'api-key';
+        elements.settingsLastFmApiSecret.value = 'shared-secret';
+        elements.settingsLastFmSessionKeyFetch.click();
+
+        await flushPromises();
+
+        expect(fetchLastFmSessionKey).toHaveBeenCalledWith('api-key', 'shared-secret');
+        expect(elements.settingsLastFmSessionKey.value).toBe('session-key-from-fetch');
+        expect(elements.settingsStatus.textContent).toBe('Last.fm session key fetched. Save settings to keep it.');
     });
 
     it('adds a scrobble rule through the rule dialog', async () => {

--- a/frontend/src/controllers/settings-controller.ts
+++ b/frontend/src/controllers/settings-controller.ts
@@ -19,6 +19,9 @@ export type SettingsFormValues = {
     libraryFolders: AppLibraryFolder[];
     ffmpegPath: string;
     listenBrainzUserToken: string;
+    lastFmApiKey: string;
+    lastFmApiSecret: string;
+    lastFmSessionKey: string;
     scrobbleFilterMode: ScrobbleFilterMode;
     scrobbleRules: ScrobbleRule[];
     musicBrainzServerUrl: string;
@@ -101,6 +104,7 @@ type SettingsControllerOptions = {
     selectLibraryFolder: () => Promise<string>;
     selectPlaylistFile: () => Promise<string>;
     save: (values: SettingsFormValues) => Promise<void>;
+    fetchLastFmSessionKey: (apiKey: string, apiSecret: string) => Promise<string>;
     applyAudioNow: (values: SettingsFormValues) => Promise<AudioOutputDevice[]>;
     forceReload: (values: SettingsFormValues) => Promise<void>;
     beforeClose?: () => Promise<string | null>;
@@ -169,6 +173,10 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
         settingsScrobbleRuleConfirm,
         settingsFFmpegPath,
         settingsListenBrainzToken,
+        settingsLastFmApiKey,
+        settingsLastFmApiSecret,
+        settingsLastFmSessionKey,
+        settingsLastFmSessionKeyFetch,
         settingsMusicBrainzServerUrl,
         settingsMusicBrainzRequestRateMs,
         settingsListenBrainzServerUrl,
@@ -227,6 +235,7 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
     let pendingScrobbleRuleResolver: ((value: ScrobbleRuleDialogValues | null) => void) | null = null;
     let scrobbleRuleReturnFocusTarget: HTMLElement | null = null;
     let forceReloadInProgress = false;
+    let lastFmSessionFetchInProgress = false;
     let forceReloadEtaSeconds: number | null = null;
     let audioOutputDevices: AudioOutputDevice[] = [];
     let coverArtPriority: CoverArtPrioritySource[] = [...defaultCoverArtPriority];
@@ -553,6 +562,9 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
         libraryFolders: libraryFolders.map((folder) => ({ ...folder })),
         ffmpegPath: settingsFFmpegPath.value,
         listenBrainzUserToken: settingsListenBrainzToken.value,
+        lastFmApiKey: settingsLastFmApiKey.value,
+        lastFmApiSecret: settingsLastFmApiSecret.value,
+        lastFmSessionKey: settingsLastFmSessionKey.value,
         scrobbleFilterMode: settingsScrobbleFilterMode.value === 'whitelist' ? 'whitelist' : 'blacklist',
         scrobbleRules: normalizeScrobbleRules(scrobbleRules).map((rule) => ({ ...rule })),
         musicBrainzServerUrl: settingsMusicBrainzServerUrl.value,
@@ -777,6 +789,11 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
                 settingsLibraryDepthStatusFadeTimer = value;
             },
         );
+    };
+
+    const refreshLastFmSessionFetchButton = (): void => {
+        settingsLastFmSessionKeyFetch.disabled = lastFmSessionFetchInProgress || settingsSave.disabled || settingsForceReload.disabled;
+        settingsLastFmSessionKeyFetch.textContent = lastFmSessionFetchInProgress ? 'Fetching...' : 'Fetch';
     };
 
     const setForceReloadEtaSeconds = (secondsRemaining: number | null): void => {
@@ -1277,6 +1294,7 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
 
     setShortcutAccordionExpanded(false, false);
     renderMusicBrainzTagWorkerProgress(musicBrainzTagWorkerProgress);
+    refreshLastFmSessionFetchButton();
 
     settingsLibraryDepthLabelInput.addEventListener('input', () => {
         setLibraryDepthStatusMessage('');
@@ -1301,6 +1319,18 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
     });
 
     settingsFFmpegPath.addEventListener('input', () => {
+        setSettingsStatusMessage('');
+    });
+
+    settingsLastFmApiKey.addEventListener('input', () => {
+        setSettingsStatusMessage('');
+    });
+
+    settingsLastFmApiSecret.addEventListener('input', () => {
+        setSettingsStatusMessage('');
+    });
+
+    settingsLastFmSessionKey.addEventListener('input', () => {
         setSettingsStatusMessage('');
     });
 
@@ -1428,6 +1458,9 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
         libraryFolders = normalizeLibraryFolders(values.libraryFolders);
         settingsFFmpegPath.value = values.ffmpegPath || '';
         settingsListenBrainzToken.value = values.listenBrainzUserToken || '';
+        settingsLastFmApiKey.value = values.lastFmApiKey || '';
+        settingsLastFmApiSecret.value = values.lastFmApiSecret || '';
+        settingsLastFmSessionKey.value = values.lastFmSessionKey || '';
         settingsScrobbleFilterMode.value = values.scrobbleFilterMode === 'whitelist' ? 'whitelist' : 'blacklist';
         scrobbleRules = normalizeScrobbleRules(values.scrobbleRules);
         settingsMusicBrainzServerUrl.value = values.musicBrainzServerUrl || '';
@@ -1469,6 +1502,7 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
         } else {
             setSettingsStatusMessage('');
         }
+        refreshLastFmSessionFetchButton();
         const primaryTab = resolvePrimaryTab(initialTab);
         const shortcutsRequested = initialTab === 'shortcuts';
         setShortcutAccordionExpanded(shortcutsRequested, false);
@@ -1652,6 +1686,52 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
             setSettingsStatusMessage('Unable to refresh audio settings right now.');
         } finally {
             settingsApplyAudioNow.disabled = false;
+        }
+    });
+
+    settingsLastFmSessionKeyFetch.addEventListener('click', async () => {
+        if (settingsLastFmSessionKeyFetch.disabled || lastFmSessionFetchInProgress) {
+            return;
+        }
+
+        const apiKey = settingsLastFmApiKey.value.trim();
+        if (apiKey === '') {
+            setSettingsStatusMessage('Enter your Last.fm API key first.');
+            settingsLastFmApiKey.focus();
+            settingsLastFmApiKey.select();
+            return;
+        }
+
+        const apiSecret = settingsLastFmApiSecret.value.trim();
+        if (apiSecret === '') {
+            setSettingsStatusMessage('Enter your Last.fm shared secret first.');
+            settingsLastFmApiSecret.focus();
+            settingsLastFmApiSecret.select();
+            return;
+        }
+
+        lastFmSessionFetchInProgress = true;
+        refreshLastFmSessionFetchButton();
+        setSettingsStatusMessage('Opening Last.fm authorization...');
+
+        try {
+            const sessionKey = (await options.fetchLastFmSessionKey(apiKey, apiSecret)).trim();
+            if (sessionKey === '') {
+                throw new Error('Last.fm returned an empty session key.');
+            }
+
+            settingsLastFmSessionKey.value = sessionKey;
+            setSettingsStatusMessage('Last.fm session key fetched. Save settings to keep it.');
+            settingsLastFmSessionKey.focus();
+            settingsLastFmSessionKey.select();
+        } catch (error) {
+            console.error(error);
+            setSettingsStatusMessage(error instanceof Error && error.message.trim() !== ''
+                ? error.message
+                : 'Unable to fetch Last.fm session key right now.');
+        } finally {
+            lastFmSessionFetchInProgress = false;
+            refreshLastFmSessionFetchButton();
         }
     });
 
@@ -1931,6 +2011,7 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
 
         settingsSave.disabled = true;
         settingsForceReload.disabled = true;
+        refreshLastFmSessionFetchButton();
 
         try {
             const formValues = buildFormValues();
@@ -1949,6 +2030,7 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
         } finally {
             settingsSave.disabled = false;
             settingsForceReload.disabled = false;
+            refreshLastFmSessionFetchButton();
         }
     });
 
@@ -1962,6 +2044,7 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
         refreshForceReloadStatus();
         settingsForceReload.disabled = true;
         settingsSave.disabled = true;
+        refreshLastFmSessionFetchButton();
 
         try {
             const formValues = buildFormValues();
@@ -1983,6 +2066,7 @@ export const createSettingsController = (options: SettingsControllerOptions) => 
         } finally {
             settingsForceReload.disabled = false;
             settingsSave.disabled = false;
+            refreshLastFmSessionFetchButton();
         }
     });
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -83,6 +83,10 @@ import {
     GetLibraryFolderPage,
     GetLibraryFolderTrackCount,
     GetLibraryFolderTrackPaths,
+    GetLastFmFollowing,
+    GetLastFmFollowingFeed,
+    GetLastFmRequestToken,
+    GetLastFmSessionKey,
     GetLibraryIndexedFilePage,
     GetListenBrainzFollowing,
     GetListenBrainzFollowingFeed,
@@ -108,6 +112,7 @@ import {
     SelectPlaylistFile,
     SelectPlaylistSaveFile,
     SelectShareImageSaveFile,
+    SubmitLastFm,
     SubmitListenBrainz,
     SubmitListenBrainzRecordingFeedback,
     ValidateFFmpegPath,
@@ -161,6 +166,7 @@ import {
     setMusicBrainzRequestLogServerResolver,
 } from './utils/musicbrainz-entity-helpers';
 import { scheduleListenBrainzRequest, scheduleMusicBrainzRequest } from './utils/musicbrainz-request-scheduler';
+import { scheduleLastFmRequest } from './utils/lastfm-request-scheduler';
 import {
     defaultFocusedKeyboardShortcuts,
     formatShortcutBindingFromKeyboardEvent,
@@ -252,6 +258,9 @@ let currentSettings: AppSettings = {
     libraryPath: '',
     ffmpegPath: '',
     listenBrainzUserToken: '',
+    lastFmApiKey: '',
+    lastFmApiSecret: '',
+    lastFmSessionKey: '',
     scrobbleFilterMode: 'blacklist',
     scrobbleRules: [],
     musicBrainzServerUrl: '',
@@ -371,6 +380,9 @@ const normalizeAppSettings = (settings: Partial<AppSettings>): AppSettings => {
         libraryPath: libraryFolders[0]?.path || '',
         ffmpegPath: (settings.ffmpegPath || '').trim(),
         listenBrainzUserToken: settings.listenBrainzUserToken || '',
+        lastFmApiKey: (settings.lastFmApiKey || '').trim(),
+        lastFmApiSecret: (settings.lastFmApiSecret || '').trim(),
+        lastFmSessionKey: (settings.lastFmSessionKey || '').trim(),
         scrobbleFilterMode: asScrobbleFilterMode(settings.scrobbleFilterMode || ''),
         scrobbleRules: normalizeScrobbleRules(settings.scrobbleRules, legacyScrobbleFolders),
         musicBrainzServerUrl: (settings.musicBrainzServerUrl || '').trim(),
@@ -449,6 +461,7 @@ const completeStartupIfReady = async (): Promise<void> => {
 
 const defaultMusicBrainzServerUrl = 'https://musicbrainz.org';
 const defaultListenBrainzServerUrl = 'https://api.listenbrainz.org';
+const defaultLastFmServerUrl = 'https://ws.audioscrobbler.com/2.0';
 
 const playbackStateService = createPlaybackStateService();
 setMusicBrainzRequestLogServerResolver(() => currentSettings.musicBrainzServerUrl || defaultMusicBrainzServerUrl);
@@ -458,6 +471,12 @@ const scrobbleService = createScrobbleService({
     ), {
         server: currentSettings.listenBrainzServerUrl || defaultListenBrainzServerUrl,
         path: '/1/submit-listens',
+    }),
+    submitLastFm: async (eventType, payload, listenedAt) => await scheduleLastFmRequest(async () => (
+        await SubmitLastFm(eventType, payload, listenedAt)
+    ), {
+        server: defaultLastFmServerUrl,
+        path: eventType === 'playing_now' ? 'track.updateNowPlaying' : 'track.scrobble',
     }),
 });
 const playbackSequencingService = createPlaybackSequencingService({
@@ -585,7 +604,10 @@ const listenBrainzController = createListenBrainzController({
         playlistController.closeMenu();
     },
 });
-const canScrobble = (): boolean => listenBrainzController.canScrobble();
+const hasListenBrainzScrobbling = (): boolean => listenBrainzController.canScrobble();
+const hasLastFmScrobbling = (): boolean => currentSettings.lastFmApiKey.trim() !== ''
+    && currentSettings.lastFmApiSecret.trim() !== ''
+    && currentSettings.lastFmSessionKey.trim() !== '';
 const closeListenBrainzFeedbackMenu = (): void => {
     listenBrainzController.closeMenu();
 };
@@ -611,20 +633,63 @@ const listenBrainzSocialController = createListenBrainzSocialController({
         socialFeedStatus,
         socialFeedList,
     },
-    getToken: () => currentSettings.listenBrainzUserToken,
+    hasAnyProviderConfigured: () => hasListenBrainzScrobbling() || hasLastFmScrobbling(),
     isSidebarVisible: () => app.classList.contains('sidebar-open'),
-    fetchFollowingUsers: async (): Promise<string[]> => await scheduleListenBrainzRequest(async () => (
-        await GetListenBrainzFollowing() as string[]
-    ), {
-        server: currentSettings.listenBrainzServerUrl || defaultListenBrainzServerUrl,
-        path: '/1/user/{user}/following',
-    }),
-    fetchFollowingFeed: async (count: number): Promise<ListenBrainzSocialEvent[]> => await scheduleListenBrainzRequest(async () => (
-        await GetListenBrainzFollowingFeed(count) as ListenBrainzSocialEvent[]
-    ), {
-        server: currentSettings.listenBrainzServerUrl || defaultListenBrainzServerUrl,
-        path: '/1/user/{user}/feed/events/listens/following',
-    }),
+    fetchFollowingUsers: async (): Promise<string[]> => {
+        const providers: Array<Promise<string[]>> = [];
+
+        if (hasListenBrainzScrobbling()) {
+            providers.push(scheduleListenBrainzRequest(async () => (
+                await GetListenBrainzFollowing() as string[]
+            ), {
+                server: currentSettings.listenBrainzServerUrl || defaultListenBrainzServerUrl,
+                path: '/1/user/{user}/following',
+            }));
+        }
+
+        if (hasLastFmScrobbling()) {
+            providers.push(scheduleLastFmRequest(async () => (
+                await GetLastFmFollowing() as string[]
+            ), {
+                server: defaultLastFmServerUrl,
+                path: 'user.getFriends',
+            }));
+        }
+
+        const merged = (await Promise.all(providers)).flat();
+        return [...new Set(merged.map((name) => name.trim()).filter((name) => name !== ''))].sort((left, right) => left.localeCompare(right));
+    },
+    fetchFollowingFeed: async (count: number): Promise<ListenBrainzSocialEvent[]> => {
+        const providers: Array<Promise<ListenBrainzSocialEvent[]>> = [];
+
+        if (hasListenBrainzScrobbling()) {
+            providers.push(scheduleListenBrainzRequest(async () => (
+                await GetListenBrainzFollowingFeed(count) as ListenBrainzSocialEvent[]
+            ), {
+                server: currentSettings.listenBrainzServerUrl || defaultListenBrainzServerUrl,
+                path: '/1/user/{user}/feed/events/listens/following',
+            }));
+        }
+
+        if (hasLastFmScrobbling()) {
+            providers.push(scheduleLastFmRequest(async () => (
+                await GetLastFmFollowingFeed(count) as ListenBrainzSocialEvent[]
+            ), {
+                server: defaultLastFmServerUrl,
+                path: 'user.getRecentTracks',
+            }));
+        }
+
+        return (await Promise.all(providers)).flat();
+    },
+    openUserProfile: (provider, userName): void => {
+        const encodedUserName = encodeURIComponent(userName);
+        const profileUrl = provider === 'lastfm'
+            ? `https://www.last.fm/user/${encodedUserName}`
+            : `${(currentSettings.listenBrainzServerUrl || 'https://listenbrainz.org').replace(/\/+$/, '')}/user/${encodedUserName}/`;
+
+        void BrowserOpenURL(profileUrl);
+    },
 });
 const openMbOnCtrlClick = (event: MouseEvent, target: HTMLElement): void => {
     if (!event.ctrlKey) {
@@ -1237,13 +1302,17 @@ const syncCurrentTrackFromPlaybackState = (state: AudioPlaybackState): void => {
         return;
     }
 
-    const activeTrack = tracks[currentTrackIndex];
-    if (activeTrack && activeTrack.path === normalizedSourcePath) {
+    const resolvedIndex = ensureTrackIndexForPath(normalizedSourcePath);
+    if (resolvedIndex < 0 || resolvedIndex >= tracks.length) {
         return;
     }
 
-    const resolvedIndex = ensureTrackIndexForPath(normalizedSourcePath);
-    if (resolvedIndex < 0 || resolvedIndex >= tracks.length) {
+    const activeTrack = tracks[currentTrackIndex];
+    if (activeTrack && trackPathKey(activeTrack.path) === trackPathKey(normalizedSourcePath)) {
+        return;
+    }
+
+    if (resolvedIndex === currentTrackIndex) {
         return;
     }
 
@@ -1252,7 +1321,7 @@ const syncCurrentTrackFromPlaybackState = (state: AudioPlaybackState): void => {
     queuedGaplessTrackPath = '';
     playlistController.scheduleRender();
     setCoverFlipped(false);
-    scrobbleService.startTrackSession();
+    scrobbleService.startTrackSession(normalizedSourcePath);
 
     const track = tracks[resolvedIndex];
     if (currentSettings.preferMusicBrainzMetadata) {
@@ -1342,7 +1411,10 @@ const queueGaplessNextTrack = async (stateOverride?: AudioPlaybackState, sequenc
 const maybeSubmitListenBrainz = (state: AudioPlaybackState): void => {
     const track = currentTrackForPlaybackState(state);
     const allowTrack = !!track && isTrackScrobbleAllowed(track, state.duration, currentSettings.scrobbleFilterMode, currentSettings.scrobbleRules);
-    scrobbleService.maybeSubmit(state, track, canScrobble() && allowTrack);
+    scrobbleService.maybeSubmit(state, track, {
+        listenBrainz: hasListenBrainzScrobbling() && allowTrack,
+        lastFm: hasLastFmScrobbling() && allowTrack,
+    });
 };
 
 const updatePlayButton = (): void => {
@@ -1827,7 +1899,7 @@ const openSidebarQueueMenu = (
         && Number.isInteger(feedbackTrackIndex)
         && (feedbackTrackIndex as number) >= 0
         && (feedbackTrackIndex as number) < tracks.length;
-    const hasListenBrainzToken = canScrobble();
+    const hasListenBrainzToken = hasListenBrainzScrobbling();
     sidebarQueueFeedbackTrackIndex = canShowFeedbackActions ? (feedbackTrackIndex as number) : null;
     sidebarQueueFeedbackDivider.hidden = !canShowFeedbackActions;
     sidebarQueueLove.hidden = !canShowFeedbackActions;
@@ -3219,8 +3291,8 @@ const loadTrack = async (index: number, allowMissingTrackRecovery = true, replay
     currentTrackIndex = index;
     playlistController.scheduleRender();
     setCoverFlipped(false);
-    scrobbleService.startTrackSession();
     const track = tracks[currentTrackIndex];
+    scrobbleService.startTrackSession(track.path);
 
     if (currentSettings.preferMusicBrainzMetadata) {
         track.mbMetadataResolved = false;
@@ -3632,6 +3704,9 @@ const savePlaybackOrderSetting = async (): Promise<void> => {
             libraryPath: currentSettings.libraryPath,
             ffmpegPath: currentSettings.ffmpegPath,
             listenBrainzUserToken: currentSettings.listenBrainzUserToken,
+            lastFmApiKey: currentSettings.lastFmApiKey,
+            lastFmApiSecret: currentSettings.lastFmApiSecret,
+            lastFmSessionKey: currentSettings.lastFmSessionKey,
             musicBrainzServerUrl: currentSettings.musicBrainzServerUrl,
             musicBrainzRequestRateMs: currentSettings.musicBrainzRequestRateMs,
             listenBrainzServerUrl: currentSettings.listenBrainzServerUrl,
@@ -3945,6 +4020,9 @@ settingsController = createSettingsController({
         libraryFolders: currentSettings.libraryFolders,
         ffmpegPath: currentSettings.ffmpegPath,
         listenBrainzUserToken: currentSettings.listenBrainzUserToken,
+        lastFmApiKey: currentSettings.lastFmApiKey,
+        lastFmApiSecret: currentSettings.lastFmApiSecret,
+        lastFmSessionKey: currentSettings.lastFmSessionKey,
         scrobbleFilterMode: currentSettings.scrobbleFilterMode,
         scrobbleRules: currentSettings.scrobbleRules,
         musicBrainzServerUrl: currentSettings.musicBrainzServerUrl,
@@ -3973,6 +4051,9 @@ settingsController = createSettingsController({
         libraryFolders: requestedLibraryFolders,
         ffmpegPath,
         listenBrainzUserToken,
+        lastFmApiKey,
+        lastFmApiSecret,
+        lastFmSessionKey,
         scrobbleFilterMode,
         scrobbleRules,
         musicBrainzServerUrl,
@@ -4005,6 +4086,9 @@ settingsController = createSettingsController({
             libraryPath: primaryLibraryFolder?.path || '',
             ffmpegPath,
             listenBrainzUserToken,
+            lastFmApiKey,
+            lastFmApiSecret,
+            lastFmSessionKey,
             scrobbleFilterMode,
             scrobbleRules,
             musicBrainzServerUrl,
@@ -4041,7 +4125,7 @@ settingsController = createSettingsController({
 
         resetShuffleHistory();
 
-        if (!canScrobble()) {
+        if (!hasListenBrainzScrobbling()) {
             closeListenBrainzFeedbackMenu();
         }
 
@@ -4061,10 +4145,34 @@ settingsController = createSettingsController({
         await completeStartupIfReady();
         void refreshListenBrainzFeedbackForCurrentTrack(true);
     },
+    fetchLastFmSessionKey: async (apiKey: string, apiSecret: string): Promise<string> => {
+        const normalizedApiKey = apiKey.trim();
+        const normalizedApiSecret = apiSecret.trim();
+        if (normalizedApiKey === '' || normalizedApiSecret === '') {
+            throw new Error('Last.fm API key and shared secret are required.');
+        }
+
+        const requestToken = await GetLastFmRequestToken(normalizedApiKey, normalizedApiSecret) as string;
+        const authorizeUrl = `https://www.last.fm/api/auth/?api_key=${encodeURIComponent(normalizedApiKey)}&token=${encodeURIComponent(requestToken)}`;
+        await BrowserOpenURL(authorizeUrl);
+
+        const confirmed = await openQueueConfirmModal(
+            'Authorize Last.fm',
+            'Allow access in your browser, then click Proceed to finish fetching the session key.',
+        );
+        if (!confirmed) {
+            throw new Error('Last.fm authorization was cancelled.');
+        }
+
+        return await GetLastFmSessionKey(normalizedApiKey, normalizedApiSecret, requestToken) as string;
+    },
     applyAudioNow: async ({
         libraryFolders: requestedLibraryFolders,
         ffmpegPath,
         listenBrainzUserToken,
+        lastFmApiKey,
+        lastFmApiSecret,
+        lastFmSessionKey,
         scrobbleFilterMode,
         scrobbleRules,
         musicBrainzServerUrl,
@@ -4097,6 +4205,9 @@ settingsController = createSettingsController({
             libraryPath: primaryLibraryFolder?.path || '',
             ffmpegPath,
             listenBrainzUserToken,
+            lastFmApiKey,
+            lastFmApiSecret,
+            lastFmSessionKey,
             scrobbleFilterMode,
             scrobbleRules,
             musicBrainzServerUrl,

--- a/frontend/src/services/scrobble-service.test.ts
+++ b/frontend/src/services/scrobble-service.test.ts
@@ -51,12 +51,12 @@ describe('createScrobbleService', () => {
             tagsResolved: false,
         });
 
-        service.maybeSubmit(state, unresolvedTrack, true);
+        service.maybeSubmit(state, unresolvedTrack, { listenBrainz: true, lastFm: false });
 
         expect(submitListenBrainz).not.toHaveBeenCalled();
 
         const resolvedTrack = createTrack({ tagsResolved: true });
-        service.maybeSubmit(state, resolvedTrack, true);
+        service.maybeSubmit(state, resolvedTrack, { listenBrainz: true, lastFm: false });
 
         expect(submitListenBrainz).toHaveBeenCalledTimes(2);
         expect(submitListenBrainz).toHaveBeenNthCalledWith(
@@ -71,5 +71,130 @@ describe('createScrobbleService', () => {
             expect.objectContaining({ artistName: 'Resolved Artist' }),
             expect.any(Number),
         );
+    });
+
+    it('tracks submission state independently per provider', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const submitListenBrainz = vi.fn(async () => undefined);
+        let lastFmAttemptCount = 0;
+        const submitLastFm = vi.fn(async () => {
+            lastFmAttemptCount += 1;
+            if (lastFmAttemptCount === 1) {
+                throw new Error('temporary failure');
+            }
+        });
+
+        const service = createScrobbleService({ submitListenBrainz, submitLastFm });
+        service.startTrackSession();
+
+        const state = createPlaybackState({ currentTime: 1 });
+        const track = createTrack();
+
+        service.maybeSubmit(state, track, { listenBrainz: true, lastFm: true });
+        await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+        });
+
+        service.maybeSubmit(state, track, { listenBrainz: true, lastFm: true });
+
+        expect(submitListenBrainz).toHaveBeenCalledTimes(1);
+        expect(submitLastFm).toHaveBeenCalledTimes(2);
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('does not resubmit when the same track session is started again', async () => {
+        const submitLastFm = vi.fn<[eventType: 'playing_now' | 'single', payload: unknown, listenedAt: number], Promise<void>>(async () => undefined);
+        const service = createScrobbleService({ submitLastFm });
+
+        const state = createPlaybackState({ currentTime: 200, duration: 300 });
+        const track = createTrack({ path: '/music/artist/album/fallback.flac' });
+
+        service.startTrackSession(track.path);
+        service.maybeSubmit(state, track, { listenBrainz: false, lastFm: true });
+        await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+        });
+
+        service.startTrackSession(track.path);
+        service.maybeSubmit(state, track, { listenBrainz: false, lastFm: true });
+
+        const singleCalls = submitLastFm.mock.calls.filter((call) => call[0] === 'single');
+        expect(singleCalls).toHaveLength(1);
+    });
+
+    it('treats slash-variant paths as the same session track', async () => {
+        const submitLastFm = vi.fn<[eventType: 'playing_now' | 'single', payload: unknown, listenedAt: number], Promise<void>>(async () => undefined);
+        const service = createScrobbleService({ submitLastFm });
+
+        const state = createPlaybackState({ currentTime: 200, duration: 300 });
+        const track = createTrack({ path: 'C:/Music/Artist/Album/track.flac' });
+
+        service.startTrackSession('C:/Music/Artist/Album/track.flac');
+        service.maybeSubmit(state, track, { listenBrainz: false, lastFm: true });
+        await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+        });
+
+        service.startTrackSession('C:\\Music\\Artist\\Album\\track.flac');
+        service.maybeSubmit(state, track, { listenBrainz: false, lastFm: true });
+
+        const singleCalls = submitLastFm.mock.calls.filter((call) => call[0] === 'single');
+        expect(singleCalls).toHaveLength(1);
+    });
+
+    it('does not retry failed Last.fm single scrobbles within the same session', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const submitLastFm = vi.fn<[eventType: 'playing_now' | 'single', payload: unknown, listenedAt: number], Promise<void>>(async (eventType) => {
+            if (eventType === 'single') {
+                throw new Error('simulated network failure');
+            }
+        });
+        const service = createScrobbleService({ submitLastFm });
+
+        const state = createPlaybackState({ currentTime: 200, duration: 300 });
+        const track = createTrack();
+
+        service.startTrackSession(track.path);
+        service.maybeSubmit(state, track, { listenBrainz: false, lastFm: true });
+        await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+        });
+
+        service.maybeSubmit(state, track, { listenBrainz: false, lastFm: true });
+
+        const singleCalls = submitLastFm.mock.calls.filter((call) => call[0] === 'single');
+        expect(singleCalls).toHaveLength(1);
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('dedupes Last.fm singles when artist label changes but track identity is the same', async () => {
+        const submitLastFm = vi.fn<[eventType: 'playing_now' | 'single', payload: unknown, listenedAt: number], Promise<void>>(async () => undefined);
+        const service = createScrobbleService({ submitLastFm });
+
+        const state = createPlaybackState({ currentTime: 200, duration: 300 });
+        const romanized = createTrack({
+            displayArtist: 'Masato Kouda',
+            displayTitle: 'コメディックスタイル',
+            displayAlbum: '「魔法戦争」オリジナルサウンドトラック',
+            mbIds: {},
+        });
+        const native = createTrack({
+            displayArtist: '甲田雅人',
+            displayTitle: 'コメディックスタイル',
+            displayAlbum: '「魔法戦争」オリジナルサウンドトラック',
+            mbIds: {},
+        });
+
+        service.startTrackSession(romanized.path);
+        service.maybeSubmit(state, romanized, { listenBrainz: false, lastFm: true });
+        await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+        });
+
+        service.startTrackSession(native.path);
+        service.maybeSubmit(state, native, { listenBrainz: false, lastFm: true });
+
+        const singleCalls = submitLastFm.mock.calls.filter((call) => call[0] === 'single');
+        expect(singleCalls).toHaveLength(1);
     });
 });

--- a/frontend/src/services/scrobble-service.ts
+++ b/frontend/src/services/scrobble-service.ts
@@ -1,32 +1,105 @@
 import type { AudioPlaybackState, Track } from '../types/app-types';
 
-type ListenBrainzPayload = {
+type ScrobblePayload = {
     artistName: string;
     trackName: string;
     releaseName: string;
+    albumArtist?: string;
+    trackNumber?: string;
+    durationSeconds?: number;
     recordingMbid?: string;
     releaseMbid?: string;
     artistMbids?: string[];
 };
 
+type ScrobbleProvider = 'listenBrainz' | 'lastFm';
+
+type ScrobbleProviderAvailability = Record<ScrobbleProvider, boolean>;
+
 type ScrobbleServiceOptions = {
-    submitListenBrainz: (eventType: 'playing_now' | 'single', payload: ListenBrainzPayload, listenedAt: number) => Promise<unknown>;
+    submitListenBrainz?: (eventType: 'playing_now' | 'single', payload: ScrobblePayload, listenedAt: number) => Promise<unknown>;
+    submitLastFm?: (eventType: 'playing_now' | 'single', payload: ScrobblePayload, listenedAt: number) => Promise<unknown>;
 };
 
 export type ScrobbleService = ReturnType<typeof createScrobbleService>;
 
 export const createScrobbleService = (options: ScrobbleServiceOptions) => {
-    let scrobbleSessionId = 0;
-    let nowPlayingSubmittedSessionId = -1;
-    let scrobbleSubmittedSessionId = -1;
-    let nowPlayingInFlight = false;
-    let scrobbleInFlight = false;
-    let scrobbleSessionStartedAt = 0;
+    const providers: ScrobbleProvider[] = ['listenBrainz', 'lastFm'];
 
-    const buildListenBrainzMetadata = (track: Track): ListenBrainzPayload => ({
-        artistName: track.displayArtist || 'Unknown Artist',
-        trackName: track.displayTitle || track.title,
-        releaseName: track.displayAlbum || 'Unknown Album',
+    const createProviderRecord = <T>(initial: T): Record<ScrobbleProvider, T> => ({
+        listenBrainz: initial,
+        lastFm: initial,
+    });
+
+    let scrobbleSessionId = 0;
+    let nowPlayingSubmittedSessionId = createProviderRecord(-1);
+    let scrobbleSubmittedSessionId = createProviderRecord(-1);
+    let nowPlayingInFlight = createProviderRecord(false);
+    let scrobbleInFlight = createProviderRecord(false);
+    let scrobbleSessionStartedAt = 0;
+    let activeSessionTrackKey = '';
+    const lastFmSingleDedupWindowSeconds = 15 * 60;
+    const lastFmRecentSingles = new Map<string, number>();
+
+    const sessionTrackKey = (trackPath: string | undefined): string => {
+        return (trackPath || '')
+            .trim()
+            .replace(/\\/g, '/')
+            .toLowerCase();
+    };
+
+    const providerSubmitters: Record<ScrobbleProvider, ScrobbleServiceOptions[keyof ScrobbleServiceOptions]> = {
+        listenBrainz: options.submitListenBrainz,
+        lastFm: options.submitLastFm,
+    };
+
+    const firstTagValue = (track: Track, ...keys: string[]): string => {
+        for (const key of keys) {
+            const normalizedKey = key.toLowerCase();
+            for (const [tagName, values] of Object.entries(track.allFileTags || {})) {
+                if (tagName.toLowerCase() !== normalizedKey) {
+                    continue;
+                }
+
+                const firstValue = values.find((value) => value.trim() !== '');
+                if (firstValue) {
+                    return firstValue.trim();
+                }
+            }
+        }
+
+        return '';
+    };
+
+    const normalizedTrackNumber = (track: Track): string | undefined => {
+        const candidate = (track.displayTrackNumber || firstTagValue(track, 'tracknumber', 'track number', 'track')).trim();
+        if (candidate === '') {
+            return undefined;
+        }
+
+        const normalized = candidate.split('/')[0]?.trim() || '';
+        return /^\d+$/.test(normalized) ? normalized : undefined;
+    };
+
+    const durationSeconds = (track: Track, stateDuration: number): number | undefined => {
+        if (Number.isFinite(stateDuration) && stateDuration > 0) {
+            return Math.round(stateDuration);
+        }
+
+        if (Number.isFinite(track.technicalDetails.durationSeconds) && (track.technicalDetails.durationSeconds || 0) > 0) {
+            return Math.round(track.technicalDetails.durationSeconds as number);
+        }
+
+        return undefined;
+    };
+
+    const buildScrobbleMetadata = (track: Track, stateDuration: number): ScrobblePayload => ({
+        artistName: track.displayArtist || firstTagValue(track, 'artist') || 'Unknown Artist',
+        trackName: track.displayTitle || track.title || track.name,
+        releaseName: track.displayAlbum || firstTagValue(track, 'album') || '',
+        albumArtist: firstTagValue(track, 'albumartist', 'album artist', 'album_artist') || undefined,
+        trackNumber: normalizedTrackNumber(track),
+        durationSeconds: durationSeconds(track, stateDuration),
         recordingMbid: track.mbIds.recordingId || undefined,
         releaseMbid: track.mbIds.releaseId || undefined,
         artistMbids: track.artistMbids.length > 0 ? track.artistMbids : undefined,
@@ -40,9 +113,102 @@ export const createScrobbleService = (options: ScrobbleServiceOptions) => {
         return Math.min(duration / 2, 240);
     };
 
+    const lastFmSingleDedupKey = (payload: ScrobblePayload): string => {
+        const recordingMbid = (payload.recordingMbid || '').trim().toLowerCase();
+        if (recordingMbid !== '') {
+            return `mbid:${recordingMbid}`;
+        }
+
+        const trackNumber = (payload.trackNumber || '').trim().toLowerCase();
+        const durationSeconds = Number.isFinite(payload.durationSeconds) ? String(payload.durationSeconds) : '';
+        return [
+            `track:${(payload.trackName || '').trim().toLowerCase()}`,
+            `release:${(payload.releaseName || '').trim().toLowerCase()}`,
+            `number:${trackNumber}`,
+            `duration:${durationSeconds}`,
+        ].join('\x1f');
+    };
+
+    const shouldSkipLastFmSingle = (payload: ScrobblePayload, listenedAt: number): boolean => {
+        if (!Number.isFinite(listenedAt) || listenedAt <= 0) {
+            return false;
+        }
+
+        const dedupKey = lastFmSingleDedupKey(payload);
+        if (dedupKey.replace(/\x1f/g, '') === '') {
+            return false;
+        }
+
+        const cutoff = listenedAt - lastFmSingleDedupWindowSeconds;
+        for (const [key, previousListenedAt] of lastFmRecentSingles.entries()) {
+            if (previousListenedAt < cutoff) {
+                lastFmRecentSingles.delete(key);
+            }
+        }
+
+        const previousListenedAt = lastFmRecentSingles.get(dedupKey);
+        if (previousListenedAt !== undefined && Math.abs(previousListenedAt - listenedAt) <= lastFmSingleDedupWindowSeconds) {
+            return true;
+        }
+
+        lastFmRecentSingles.set(dedupKey, listenedAt);
+        return false;
+    };
+
+    const submitForProvider = (
+        provider: ScrobbleProvider,
+        eventType: 'playing_now' | 'single',
+        payload: ScrobblePayload,
+        listenedAt: number,
+    ): void => {
+        const submit = providerSubmitters[provider];
+        if (!submit) {
+            return;
+        }
+
+        if (eventType === 'playing_now') {
+            nowPlayingInFlight[provider] = true;
+        } else {
+            scrobbleInFlight[provider] = true;
+            if (provider === 'lastFm') {
+                // Last.fm can occasionally accept a scrobble even when the client sees an error.
+                // Mark this session submitted before awaiting the response to avoid duplicates.
+                scrobbleSubmittedSessionId[provider] = scrobbleSessionId;
+            }
+        }
+
+        void submit(eventType, payload, listenedAt)
+            .then(() => {
+                if (eventType === 'playing_now') {
+                    nowPlayingSubmittedSessionId[provider] = scrobbleSessionId;
+                    return;
+                }
+
+                if (provider !== 'lastFm') {
+                    scrobbleSubmittedSessionId[provider] = scrobbleSessionId;
+                }
+            })
+            .catch((error) => {
+                console.error(error);
+            })
+            .finally(() => {
+                if (eventType === 'playing_now') {
+                    nowPlayingInFlight[provider] = false;
+                    return;
+                }
+
+                scrobbleInFlight[provider] = false;
+            });
+    };
+
     return {
-        maybeSubmit: (state: AudioPlaybackState, track: Track | undefined, canScrobble: boolean): void => {
-            if (!canScrobble || !track) {
+        maybeSubmit: (state: AudioPlaybackState, track: Track | undefined, availability: ScrobbleProviderAvailability): void => {
+            if (!track) {
+                return;
+            }
+
+            const enabledProviders = providers.filter((provider) => availability[provider]);
+            if (enabledProviders.length === 0) {
                 return;
             }
 
@@ -54,22 +220,16 @@ export const createScrobbleService = (options: ScrobbleServiceOptions) => {
                 return;
             }
 
-            if (state.playing && nowPlayingSubmittedSessionId !== scrobbleSessionId && !nowPlayingInFlight) {
-                nowPlayingInFlight = true;
-                void options.submitListenBrainz('playing_now', buildListenBrainzMetadata(track), 0)
-                    .then(() => {
-                        nowPlayingSubmittedSessionId = scrobbleSessionId;
-                    })
-                    .catch((error) => {
-                        console.error(error);
-                    })
-                    .finally(() => {
-                        nowPlayingInFlight = false;
-                    });
-            }
+            const payload = buildScrobbleMetadata(track, state.duration);
 
-            if (scrobbleSubmittedSessionId === scrobbleSessionId || scrobbleInFlight) {
-                return;
+            if (state.playing) {
+                for (const provider of enabledProviders) {
+                    if (nowPlayingSubmittedSessionId[provider] === scrobbleSessionId || nowPlayingInFlight[provider]) {
+                        continue;
+                    }
+
+                    submitForProvider(provider, 'playing_now', payload, 0);
+                }
             }
 
             const threshold = scrobbleThreshold(state.duration);
@@ -78,31 +238,39 @@ export const createScrobbleService = (options: ScrobbleServiceOptions) => {
             }
 
             const listenedAt = scrobbleSessionStartedAt > 0 ? scrobbleSessionStartedAt : Math.floor(Date.now() / 1000);
-            scrobbleInFlight = true;
-            void options.submitListenBrainz('single', buildListenBrainzMetadata(track), listenedAt)
-                .then(() => {
-                    scrobbleSubmittedSessionId = scrobbleSessionId;
-                })
-                .catch((error) => {
-                    console.error(error);
-                })
-                .finally(() => {
-                    scrobbleInFlight = false;
-                });
+            for (const provider of enabledProviders) {
+                if (scrobbleSubmittedSessionId[provider] === scrobbleSessionId || scrobbleInFlight[provider]) {
+                    continue;
+                }
+
+                if (provider === 'lastFm' && shouldSkipLastFmSingle(payload, listenedAt)) {
+                    scrobbleSubmittedSessionId[provider] = scrobbleSessionId;
+                    continue;
+                }
+
+                submitForProvider(provider, 'single', payload, listenedAt);
+            }
         },
         reset: (): void => {
             scrobbleSessionId = 0;
-            nowPlayingSubmittedSessionId = -1;
-            scrobbleSubmittedSessionId = -1;
-            nowPlayingInFlight = false;
-            scrobbleInFlight = false;
+            nowPlayingSubmittedSessionId = createProviderRecord(-1);
+            scrobbleSubmittedSessionId = createProviderRecord(-1);
+            nowPlayingInFlight = createProviderRecord(false);
+            scrobbleInFlight = createProviderRecord(false);
             scrobbleSessionStartedAt = 0;
+            activeSessionTrackKey = '';
         },
-        startTrackSession: (): void => {
+        startTrackSession: (trackPath?: string): void => {
+            const nextTrackKey = sessionTrackKey(trackPath);
+            if (nextTrackKey !== '' && nextTrackKey === activeSessionTrackKey) {
+                return;
+            }
+
             scrobbleSessionId += 1;
-            nowPlayingSubmittedSessionId = -1;
-            scrobbleSubmittedSessionId = -1;
+            nowPlayingSubmittedSessionId = createProviderRecord(-1);
+            scrobbleSubmittedSessionId = createProviderRecord(-1);
             scrobbleSessionStartedAt = 0;
+            activeSessionTrackKey = nextTrackKey;
         },
     };
 };

--- a/frontend/src/types/app-types.ts
+++ b/frontend/src/types/app-types.ts
@@ -304,6 +304,9 @@ export type AppSettings = {
     libraryPath: string;
     ffmpegPath: string;
     listenBrainzUserToken: string;
+    lastFmApiKey: string;
+    lastFmApiSecret: string;
+    lastFmSessionKey: string;
     scrobbleFilterMode: ScrobbleFilterMode;
     scrobbleRules: ScrobbleRule[];
     musicBrainzServerUrl: string;

--- a/frontend/src/utils/lastfm-request-scheduler.test.ts
+++ b/frontend/src/utils/lastfm-request-scheduler.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadScheduler = async () => {
+    vi.resetModules();
+    return import('./lastfm-request-scheduler');
+};
+
+describe('scheduleLastFmRequest', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('does not queue requests in direct mode', async () => {
+        const { scheduleLastFmRequest } = await loadScheduler();
+        const callOrder: string[] = [];
+        let resolveFirstRequest!: (value: string) => void;
+
+        const firstRequest = scheduleLastFmRequest(async () => {
+            callOrder.push('first');
+            return await new Promise<string>((resolve) => {
+                resolveFirstRequest = resolve;
+            });
+        });
+
+        const secondRequest = scheduleLastFmRequest(async () => {
+            callOrder.push('second');
+            return 'second';
+        });
+
+        await Promise.resolve();
+        expect(callOrder).toEqual(['first', 'second']);
+
+        resolveFirstRequest('first');
+        await expect(firstRequest).resolves.toBe('first');
+        await expect(secondRequest).resolves.toBe('second');
+    });
+
+    it('logs Last.fm requests in direct mode', async () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+        const { scheduleLastFmRequest } = await loadScheduler();
+
+        await expect(scheduleLastFmRequest(async () => 'first', {
+            server: 'https://ws.audioscrobbler.com/2.0',
+            path: 'track.scrobble',
+        })).resolves.toBe('first');
+
+        await expect(scheduleLastFmRequest(async () => 'second')).resolves.toBe('second');
+
+        expect(infoSpy).toHaveBeenCalledTimes(2);
+        expect(infoSpy.mock.calls[0]?.[0]).toContain('[LFM] network request:');
+        expect(infoSpy.mock.calls[0]?.[0]).toContain('server=https://ws.audioscrobbler.com/2.0');
+        expect(infoSpy.mock.calls[0]?.[0]).toContain('path=track.scrobble');
+        expect(infoSpy.mock.calls[1]?.[0]).toContain('[LFM] network request:');
+    });
+});

--- a/frontend/src/utils/lastfm-request-scheduler.ts
+++ b/frontend/src/utils/lastfm-request-scheduler.ts
@@ -1,0 +1,17 @@
+import type { RequestTarget } from './musicbrainz-request-scheduler';
+
+const normalizeRequestTarget = (target?: RequestTarget): { server: string; path: string } => {
+    const server = target?.server?.trim() || '(unknown-server)';
+    const path = target?.path?.trim() || '(unknown-path)';
+    return { server, path };
+};
+
+const logLastFmNetworkRequest = (details: string, target?: RequestTarget): void => {
+    const normalizedTarget = normalizeRequestTarget(target);
+    console.info(`[LFM] network request: server=${normalizedTarget.server} path=${normalizedTarget.path} ${details}`);
+};
+
+export const scheduleLastFmRequest = async <T>(request: () => Promise<T>, target?: RequestTarget): Promise<T> => {
+    logLastFmNetworkRequest('queued=false waitMs=0 cooldownMs=0', target);
+    return await request();
+};

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -32,6 +32,14 @@ export function AudioStop():Promise<main.AudioPlaybackState>;
 
 export function GetAppVersion():Promise<string>;
 
+export function GetLastFmFollowing():Promise<Array<string>>;
+
+export function GetLastFmFollowingFeed(arg1:number):Promise<Array<main.ListenBrainzSocialEvent>>;
+
+export function GetLastFmRequestToken(arg1:string,arg2:string):Promise<string>;
+
+export function GetLastFmSessionKey(arg1:string,arg2:string,arg3:string):Promise<string>;
+
 export function GetLibraryFolderCoverPath(arg1:string):Promise<string>;
 
 export function GetLibraryFolderPage(arg1:string,arg2:number,arg3:number):Promise<main.LibraryFolderPage>;
@@ -105,6 +113,8 @@ export function SelectPlaylistSaveFile():Promise<string>;
 export function SelectShareImageSaveFile(arg1:string):Promise<string>;
 
 export function ShowErrorDialog(arg1:string,arg2:string):Promise<void>;
+
+export function SubmitLastFm(arg1:string,arg2:main.LastFmTrackMetadata,arg3:number):Promise<void>;
 
 export function SubmitListenBrainz(arg1:string,arg2:main.ListenBrainzTrackMetadata,arg3:number):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -62,6 +62,22 @@ export function GetAppVersion() {
   return window['go']['main']['App']['GetAppVersion']();
 }
 
+export function GetLastFmFollowing() {
+  return window['go']['main']['App']['GetLastFmFollowing']();
+}
+
+export function GetLastFmFollowingFeed(arg1) {
+  return window['go']['main']['App']['GetLastFmFollowingFeed'](arg1);
+}
+
+export function GetLastFmRequestToken(arg1, arg2) {
+  return window['go']['main']['App']['GetLastFmRequestToken'](arg1, arg2);
+}
+
+export function GetLastFmSessionKey(arg1, arg2, arg3) {
+  return window['go']['main']['App']['GetLastFmSessionKey'](arg1, arg2, arg3);
+}
+
 export function GetLibraryFolderCoverPath(arg1) {
   return window['go']['main']['App']['GetLibraryFolderCoverPath'](arg1);
 }
@@ -208,6 +224,10 @@ export function SelectShareImageSaveFile(arg1) {
 
 export function ShowErrorDialog(arg1, arg2) {
   return window['go']['main']['App']['ShowErrorDialog'](arg1, arg2);
+}
+
+export function SubmitLastFm(arg1, arg2, arg3) {
+  return window['go']['main']['App']['SubmitLastFm'](arg1, arg2, arg3);
 }
 
 export function SubmitListenBrainz(arg1, arg2, arg3) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -77,6 +77,9 @@ export namespace main {
 	    libraryPath?: string;
 	    ffmpegPath?: string;
 	    listenBrainzUserToken: string;
+	    lastFmApiKey: string;
+	    lastFmApiSecret: string;
+	    lastFmSessionKey: string;
 	    scrobbleFilterMode?: string;
 	    scrobbleRules?: ScrobbleRule[];
 	    scrobbleFolders?: string[];
@@ -107,6 +110,9 @@ export namespace main {
 	        this.libraryPath = source["libraryPath"];
 	        this.ffmpegPath = source["ffmpegPath"];
 	        this.listenBrainzUserToken = source["listenBrainzUserToken"];
+	        this.lastFmApiKey = source["lastFmApiKey"];
+	        this.lastFmApiSecret = source["lastFmApiSecret"];
+	        this.lastFmSessionKey = source["lastFmSessionKey"];
 	        this.scrobbleFilterMode = source["scrobbleFilterMode"];
 	        this.scrobbleRules = this.convertValues(source["scrobbleRules"], ScrobbleRule);
 	        this.scrobbleFolders = source["scrobbleFolders"];
@@ -222,6 +228,30 @@ export namespace main {
 	    }
 	}
 	
+	export class LastFmTrackMetadata {
+	    artistName: string;
+	    trackName: string;
+	    releaseName?: string;
+	    albumArtist?: string;
+	    trackNumber?: string;
+	    recordingMbid?: string;
+	    durationSeconds?: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new LastFmTrackMetadata(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.artistName = source["artistName"];
+	        this.trackName = source["trackName"];
+	        this.releaseName = source["releaseName"];
+	        this.albumArtist = source["albumArtist"];
+	        this.trackNumber = source["trackNumber"];
+	        this.recordingMbid = source["recordingMbid"];
+	        this.durationSeconds = source["durationSeconds"];
+	    }
+	}
 	export class LibraryBrowserEntry {
 	    kind: string;
 	    name: string;

--- a/lastfm.go
+++ b/lastfm.go
@@ -1,0 +1,740 @@
+package main
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var lastFmAPIBaseURL = "https://ws.audioscrobbler.com/2.0"
+
+const lastFmDuplicateScrobbleWindow = 15 * time.Minute
+
+type lastFmScrobbleDedupEntry struct {
+	seenAt     time.Time
+	listenedAt int64
+}
+
+type lastFmErrorResponse struct {
+	Code    int    `xml:"code,attr"`
+	Message string `xml:",chardata"`
+}
+
+type lastFmAPIResponse struct {
+	XMLName xml.Name             `xml:"lfm"`
+	Status  string               `xml:"status,attr"`
+	Error   *lastFmErrorResponse `xml:"error"`
+}
+
+type lastFmGetTokenResponse struct {
+	XMLName xml.Name             `xml:"lfm"`
+	Status  string               `xml:"status,attr"`
+	Error   *lastFmErrorResponse `xml:"error"`
+	Token   string               `xml:"token"`
+}
+
+type lastFmGetSessionResponse struct {
+	XMLName xml.Name             `xml:"lfm"`
+	Status  string               `xml:"status,attr"`
+	Error   *lastFmErrorResponse `xml:"error"`
+	Session struct {
+		Name string `xml:"name"`
+		Key  string `xml:"key"`
+	} `xml:"session"`
+}
+
+type lastFmJSONErrorResponse struct {
+	Error   int    `json:"error"`
+	Message string `json:"message"`
+}
+
+type lastFmUserGetInfoResponse struct {
+	lastFmJSONErrorResponse
+	User struct {
+		Name string `json:"name"`
+	} `json:"user"`
+}
+
+type lastFmUserGetFriendsResponse struct {
+	lastFmJSONErrorResponse
+	Friends struct {
+		Users []struct {
+			Name string `json:"name"`
+		} `json:"user"`
+	} `json:"friends"`
+}
+
+type lastFmUserGetRecentTracksResponse struct {
+	lastFmJSONErrorResponse
+	RecentTracks struct {
+		Tracks []struct {
+			Name   string `json:"name"`
+			Artist struct {
+				Name string `json:"#text"`
+			} `json:"artist"`
+			Album struct {
+				Name string `json:"#text"`
+			} `json:"album"`
+			MBID string `json:"mbid"`
+			Date struct {
+				UnixTime string `json:"uts"`
+			} `json:"date"`
+			Attr struct {
+				NowPlaying string `json:"nowplaying"`
+			} `json:"@attr"`
+		} `json:"track"`
+	} `json:"recenttracks"`
+}
+
+// LastFmTrackMetadata stores the frontend-facing metadata shape for Last.fm submissions.
+type LastFmTrackMetadata struct {
+	ArtistName      string `json:"artistName"`
+	TrackName       string `json:"trackName"`
+	ReleaseName     string `json:"releaseName,omitempty"`
+	AlbumArtist     string `json:"albumArtist,omitempty"`
+	TrackNumber     string `json:"trackNumber,omitempty"`
+	RecordingMBID   string `json:"recordingMbid,omitempty"`
+	DurationSeconds int    `json:"durationSeconds,omitempty"`
+}
+
+func signLastFmParams(params map[string]string, secret string) string {
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	builder := strings.Builder{}
+	for _, key := range keys {
+		builder.WriteString(key)
+		builder.WriteString(params[key])
+	}
+	builder.WriteString(secret)
+
+	sum := md5.Sum([]byte(builder.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+func parseLastFmResponse(responseBody []byte, fallback string) error {
+	parsedResponse := lastFmAPIResponse{}
+	if err := xml.Unmarshal(responseBody, &parsedResponse); err != nil {
+		if strings.TrimSpace(string(responseBody)) == "" {
+			return nil
+		}
+
+		return errors.New(fallback)
+	}
+
+	if strings.EqualFold(strings.TrimSpace(parsedResponse.Status), "ok") {
+		return nil
+	}
+
+	if parsedResponse.Error != nil {
+		message := strings.TrimSpace(parsedResponse.Error.Message)
+		if message != "" {
+			return errors.New(message)
+		}
+	}
+
+	return errors.New(fallback)
+}
+
+func lastFmAuthCredentials(apiKey string, apiSecret string) (string, string, error) {
+	cleanAPIKey := strings.TrimSpace(apiKey)
+	cleanAPISecret := strings.TrimSpace(apiSecret)
+	if cleanAPIKey == "" || cleanAPISecret == "" {
+		return "", "", errors.New("last.fm auth requires both API key and shared secret")
+	}
+
+	return cleanAPIKey, cleanAPISecret, nil
+}
+
+func callLastFmAPI(params map[string]string) ([]byte, error) {
+	requestBody := url.Values{}
+	for key, value := range params {
+		requestBody.Set(key, value)
+	}
+
+	httpRequest, err := http.NewRequest(http.MethodPost, lastFmAPIBaseURL, strings.NewReader(requestBody.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	httpRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	response, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	responseBody, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("unable to read last.fm response")
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		fallback := fmt.Sprintf("last.fm request failed with status %d", response.StatusCode)
+		if parseErr := parseLastFmResponse(responseBody, fallback); parseErr != nil {
+			return nil, parseErr
+		}
+
+		return nil, errors.New(fallback)
+	}
+
+	return responseBody, nil
+}
+
+func callLastFmReadAPI(params map[string]string) ([]byte, error) {
+	requestQuery := url.Values{}
+	for key, value := range params {
+		requestQuery.Set(key, value)
+	}
+	requestQuery.Set("format", "json")
+
+	endpoint := strings.TrimRight(lastFmAPIBaseURL, "/") + "?" + requestQuery.Encode()
+	httpRequest, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpRequest.Header.Set("Accept", "application/json")
+
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	response, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	responseBody, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		return nil, fmt.Errorf("unable to read last.fm response")
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		parsedError := lastFmJSONErrorResponse{}
+		if err := json.Unmarshal(responseBody, &parsedError); err == nil {
+			if strings.TrimSpace(parsedError.Message) != "" {
+				return nil, errors.New(strings.TrimSpace(parsedError.Message))
+			}
+		}
+
+		return nil, fmt.Errorf("last.fm request failed with status %d", response.StatusCode)
+	}
+
+	parsedError := lastFmJSONErrorResponse{}
+	if err := json.Unmarshal(responseBody, &parsedError); err == nil {
+		if strings.TrimSpace(parsedError.Message) != "" && parsedError.Error != 0 {
+			return nil, errors.New(strings.TrimSpace(parsedError.Message))
+		}
+	}
+
+	return responseBody, nil
+}
+
+// GetLastFmRequestToken requests a desktop-auth request token from Last.fm.
+func (a *App) GetLastFmRequestToken(apiKey string, apiSecret string) (string, error) {
+	cleanAPIKey, cleanAPISecret, err := lastFmAuthCredentials(apiKey, apiSecret)
+	if err != nil {
+		return "", err
+	}
+
+	params := map[string]string{
+		"api_key": cleanAPIKey,
+		"method":  "auth.getToken",
+	}
+	params["api_sig"] = signLastFmParams(params, cleanAPISecret)
+
+	responseBody, err := callLastFmAPI(params)
+	if err != nil {
+		return "", err
+	}
+
+	parsedResponse := lastFmGetTokenResponse{}
+	if err := xml.Unmarshal(responseBody, &parsedResponse); err != nil {
+		return "", errors.New("invalid last.fm auth token response")
+	}
+	if !strings.EqualFold(strings.TrimSpace(parsedResponse.Status), "ok") {
+		if parsedResponse.Error != nil && strings.TrimSpace(parsedResponse.Error.Message) != "" {
+			return "", errors.New(strings.TrimSpace(parsedResponse.Error.Message))
+		}
+
+		return "", errors.New("last.fm auth token request failed")
+	}
+
+	token := strings.TrimSpace(parsedResponse.Token)
+	if token == "" {
+		return "", errors.New("last.fm auth token response did not include a token")
+	}
+
+	return token, nil
+}
+
+// GetLastFmSessionKey exchanges an authorized request token for a Last.fm session key.
+func (a *App) GetLastFmSessionKey(apiKey string, apiSecret string, requestToken string) (string, error) {
+	cleanAPIKey, cleanAPISecret, err := lastFmAuthCredentials(apiKey, apiSecret)
+	if err != nil {
+		return "", err
+	}
+
+	cleanRequestToken := strings.TrimSpace(requestToken)
+	if cleanRequestToken == "" {
+		return "", errors.New("last.fm session exchange requires a request token")
+	}
+
+	params := map[string]string{
+		"api_key": cleanAPIKey,
+		"method":  "auth.getSession",
+		"token":   cleanRequestToken,
+	}
+	params["api_sig"] = signLastFmParams(params, cleanAPISecret)
+
+	responseBody, err := callLastFmAPI(params)
+	if err != nil {
+		return "", err
+	}
+
+	parsedResponse := lastFmGetSessionResponse{}
+	if err := xml.Unmarshal(responseBody, &parsedResponse); err != nil {
+		return "", errors.New("invalid last.fm session response")
+	}
+	if !strings.EqualFold(strings.TrimSpace(parsedResponse.Status), "ok") {
+		if parsedResponse.Error != nil && strings.TrimSpace(parsedResponse.Error.Message) != "" {
+			return "", errors.New(strings.TrimSpace(parsedResponse.Error.Message))
+		}
+
+		return "", errors.New("last.fm session request failed")
+	}
+
+	sessionKey := strings.TrimSpace(parsedResponse.Session.Key)
+	if sessionKey == "" {
+		return "", errors.New("last.fm session response did not include a session key")
+	}
+
+	return sessionKey, nil
+}
+
+func (a *App) lastFmCredentials() (string, string, string, error) {
+	a.ensureSettingsLoaded()
+
+	apiKey := strings.TrimSpace(a.settings.LastFmAPIKey)
+	apiSecret := strings.TrimSpace(a.settings.LastFmAPISecret)
+	sessionKey := strings.TrimSpace(a.settings.LastFmSessionKey)
+	if apiKey == "" || apiSecret == "" || sessionKey == "" {
+		return "", "", "", errors.New("last.fm scrobbling requires an API key, shared secret, and session key")
+	}
+
+	return apiKey, apiSecret, sessionKey, nil
+}
+
+func lastFmDurationSeconds(value int) string {
+	if value <= 0 {
+		return ""
+	}
+
+	return strconv.Itoa(value)
+}
+
+func lastFmTrackNumber(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+
+	if slashIndex := strings.Index(trimmed, "/"); slashIndex >= 0 {
+		trimmed = strings.TrimSpace(trimmed[:slashIndex])
+	}
+
+	if trimmed == "" {
+		return ""
+	}
+
+	parsed, err := strconv.Atoi(trimmed)
+	if err != nil || parsed <= 0 {
+		return ""
+	}
+
+	return strconv.Itoa(parsed)
+}
+
+func absInt64(value int64) int64 {
+	if value < 0 {
+		return -value
+	}
+
+	return value
+}
+
+func lastFmScrobbleFingerprint(metadata LastFmTrackMetadata) string {
+	cleanRecordingMBID := strings.ToLower(strings.TrimSpace(metadata.RecordingMBID))
+	if cleanRecordingMBID != "" {
+		return "mbid:" + cleanRecordingMBID
+	}
+
+	cleanTrackName := strings.ToLower(strings.TrimSpace(metadata.TrackName))
+	cleanReleaseName := strings.ToLower(strings.TrimSpace(metadata.ReleaseName))
+	cleanTrackNumber := strings.ToLower(strings.TrimSpace(lastFmTrackNumber(metadata.TrackNumber)))
+	cleanDuration := strconv.Itoa(metadata.DurationSeconds)
+
+	return strings.Join([]string{
+		"track:" + cleanTrackName,
+		"release:" + cleanReleaseName,
+		"number:" + cleanTrackNumber,
+		"duration:" + cleanDuration,
+	}, "\x1f")
+}
+
+func (a *App) shouldSkipLastFmDuplicateScrobble(metadata LastFmTrackMetadata, listenedAt int64) bool {
+	if listenedAt <= 0 {
+		return false
+	}
+
+	cleanArtistName := strings.ToLower(strings.TrimSpace(metadata.ArtistName))
+	cleanTrackName := strings.ToLower(strings.TrimSpace(metadata.TrackName))
+	if cleanArtistName == "" || cleanTrackName == "" {
+		return false
+	}
+	duplicateKey := lastFmScrobbleFingerprint(metadata)
+
+	now := time.Now()
+	a.lastFmScrobbleMu.Lock()
+	defer a.lastFmScrobbleMu.Unlock()
+
+	if a.lastFmRecentScrobbles == nil {
+		a.lastFmRecentScrobbles = make(map[string]lastFmScrobbleDedupEntry)
+	}
+
+	cutoff := now.Add(-lastFmDuplicateScrobbleWindow)
+	for key, entry := range a.lastFmRecentScrobbles {
+		if entry.seenAt.Before(cutoff) {
+			delete(a.lastFmRecentScrobbles, key)
+		}
+	}
+
+	if entry, found := a.lastFmRecentScrobbles[duplicateKey]; found && !entry.seenAt.Before(cutoff) {
+		if absInt64(entry.listenedAt-listenedAt) <= int64(lastFmDuplicateScrobbleWindow/time.Second) {
+			return true
+		}
+	}
+
+	a.lastFmRecentScrobbles[duplicateKey] = lastFmScrobbleDedupEntry{
+		seenAt:     now,
+		listenedAt: listenedAt,
+	}
+	return false
+}
+
+// SubmitLastFm sends a now-playing or scrobble event to the Last.fm API.
+func (a *App) SubmitLastFm(listenType string, metadata LastFmTrackMetadata, listenedAt int64) error {
+	apiKey, apiSecret, sessionKey, err := a.lastFmCredentials()
+	if err != nil {
+		return err
+	}
+
+	cleanArtistName := strings.TrimSpace(metadata.ArtistName)
+	cleanTrackName := strings.TrimSpace(metadata.TrackName)
+	if cleanArtistName == "" || cleanTrackName == "" {
+		return errors.New("artist name and track name are required for Last.fm submissions")
+	}
+
+	normalizedType := strings.TrimSpace(strings.ToLower(listenType))
+	methodName := ""
+	submitTimestamp := int64(0)
+	switch normalizedType {
+	case "playing_now":
+		methodName = "track.updateNowPlaying"
+	case "single":
+		methodName = "track.scrobble"
+		if listenedAt <= 0 {
+			listenedAt = time.Now().Unix()
+		}
+		if a.shouldSkipLastFmDuplicateScrobble(metadata, listenedAt) {
+			return nil
+		}
+		submitTimestamp = listenedAt
+	default:
+		return errors.New("listen type must be either playing_now or single")
+	}
+
+	params := map[string]string{
+		"api_key": apiKey,
+		"artist":  cleanArtistName,
+		"method":  methodName,
+		"sk":      sessionKey,
+		"track":   cleanTrackName,
+	}
+
+	if releaseName := strings.TrimSpace(metadata.ReleaseName); releaseName != "" {
+		params["album"] = releaseName
+	}
+	if albumArtist := strings.TrimSpace(metadata.AlbumArtist); albumArtist != "" {
+		params["albumArtist"] = albumArtist
+	}
+	if trackNumber := lastFmTrackNumber(metadata.TrackNumber); trackNumber != "" {
+		params["trackNumber"] = trackNumber
+	}
+	if recordingMBID := strings.TrimSpace(metadata.RecordingMBID); recordingMBID != "" {
+		params["mbid"] = recordingMBID
+	}
+	if durationSeconds := lastFmDurationSeconds(metadata.DurationSeconds); durationSeconds != "" {
+		params["duration"] = durationSeconds
+	}
+	if submitTimestamp > 0 {
+		params["timestamp"] = strconv.FormatInt(submitTimestamp, 10)
+	}
+
+	params["api_sig"] = signLastFmParams(params, apiSecret)
+
+	requestBody := url.Values{}
+	for key, value := range params {
+		requestBody.Set(key, value)
+	}
+
+	httpRequest, err := http.NewRequest(http.MethodPost, lastFmAPIBaseURL, strings.NewReader(requestBody.Encode()))
+	if err != nil {
+		return err
+	}
+
+	httpRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	response, err := httpClient.Do(httpRequest)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	responseBody, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		return fmt.Errorf("unable to read last.fm response")
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		fallback := fmt.Sprintf("last.fm request failed with status %d", response.StatusCode)
+		if parseErr := parseLastFmResponse(responseBody, fallback); parseErr != nil {
+			return parseErr
+		}
+
+		return errors.New(fallback)
+	}
+
+	fallback := "invalid last.fm response"
+	if parseErr := parseLastFmResponse(responseBody, fallback); parseErr != nil {
+		return parseErr
+	}
+
+	return nil
+}
+
+func (a *App) lastFmSessionCredentials() (string, string, error) {
+	a.ensureSettingsLoaded()
+
+	apiKey := strings.TrimSpace(a.settings.LastFmAPIKey)
+	sessionKey := strings.TrimSpace(a.settings.LastFmSessionKey)
+	if apiKey == "" || sessionKey == "" {
+		return "", "", errors.New("last.fm social feed requires an API key and session key")
+	}
+
+	return apiKey, sessionKey, nil
+}
+
+// GetLastFmFollowing returns the Last.fm friends list for the authenticated user.
+func (a *App) GetLastFmFollowing() ([]string, error) {
+	apiKey, sessionKey, err := a.lastFmSessionCredentials()
+	if err != nil {
+		return nil, err
+	}
+
+	infoBody, err := callLastFmReadAPI(map[string]string{
+		"method":  "user.getinfo",
+		"api_key": apiKey,
+		"sk":      sessionKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	infoResponse := lastFmUserGetInfoResponse{}
+	if err := json.Unmarshal(infoBody, &infoResponse); err != nil {
+		return nil, errors.New("invalid last.fm user info response")
+	}
+
+	userName := strings.TrimSpace(infoResponse.User.Name)
+	if userName == "" {
+		return nil, errors.New("last.fm user info response did not include a username")
+	}
+
+	friendsBody, err := callLastFmReadAPI(map[string]string{
+		"method":  "user.getfriends",
+		"api_key": apiKey,
+		"user":    userName,
+		"limit":   "200",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	friendsResponse := lastFmUserGetFriendsResponse{}
+	if err := json.Unmarshal(friendsBody, &friendsResponse); err != nil {
+		return nil, errors.New("invalid last.fm friends response")
+	}
+
+	seen := make(map[string]struct{})
+	following := make([]string, 0, len(friendsResponse.Friends.Users))
+	for _, friend := range friendsResponse.Friends.Users {
+		name := strings.TrimSpace(friend.Name)
+		if name == "" {
+			continue
+		}
+		normalized := strings.ToLower(name)
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		following = append(following, name)
+	}
+
+	sort.Strings(following)
+	return following, nil
+}
+
+func normalizeLastFmSocialCount(count int) int {
+	if count <= 0 {
+		return 25
+	}
+
+	if count > 200 {
+		return 200
+	}
+
+	return count
+}
+
+func stableLastFmSocialID(userName string, trackName string, listenedAt int64) int {
+	hashSeed := strings.ToLower(strings.TrimSpace(userName)) + "\x1f" + strings.TrimSpace(trackName) + "\x1f" + strconv.FormatInt(listenedAt, 10)
+	hash := md5.Sum([]byte(hashSeed))
+	return int(uint32(hash[0])<<24 | uint32(hash[1])<<16 | uint32(hash[2])<<8 | uint32(hash[3]))
+}
+
+func parseLastFmUnixTimestamp(value string) int64 {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0
+	}
+
+	parsed, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil || parsed <= 0 {
+		return 0
+	}
+
+	return parsed
+}
+
+// GetLastFmFollowingFeed returns recent listens for followed Last.fm users.
+func (a *App) GetLastFmFollowingFeed(count int) ([]ListenBrainzSocialEvent, error) {
+	apiKey, _, err := a.lastFmSessionCredentials()
+	if err != nil {
+		return nil, err
+	}
+
+	followingUsers, err := a.GetLastFmFollowing()
+	if err != nil {
+		return nil, err
+	}
+
+	maxUsers := normalizeLastFmSocialCount(count)
+	if len(followingUsers) > maxUsers {
+		followingUsers = followingUsers[:maxUsers]
+	}
+
+	events := make([]ListenBrainzSocialEvent, 0, len(followingUsers))
+	for _, friend := range followingUsers {
+		recentTracksBody, requestErr := callLastFmReadAPI(map[string]string{
+			"method":  "user.getrecenttracks",
+			"api_key": apiKey,
+			"user":    friend,
+			"limit":   "1",
+		})
+		if requestErr != nil {
+			continue
+		}
+
+		recentTracksResponse := lastFmUserGetRecentTracksResponse{}
+		if unmarshalErr := json.Unmarshal(recentTracksBody, &recentTracksResponse); unmarshalErr != nil {
+			continue
+		}
+
+		if len(recentTracksResponse.RecentTracks.Tracks) == 0 {
+			continue
+		}
+
+		track := recentTracksResponse.RecentTracks.Tracks[0]
+		trackName := strings.TrimSpace(track.Name)
+		if trackName == "" {
+			continue
+		}
+
+		artistName := strings.TrimSpace(track.Artist.Name)
+		if artistName == "" {
+			artistName = "Unknown artist"
+		}
+
+		listenedAt := parseLastFmUnixTimestamp(track.Date.UnixTime)
+		playingNow := strings.EqualFold(strings.TrimSpace(track.Attr.NowPlaying), "true")
+		if playingNow && listenedAt <= 0 {
+			listenedAt = time.Now().Unix()
+		}
+
+		eventID := stableLastFmSocialID(friend, trackName, listenedAt)
+		events = append(events, ListenBrainzSocialEvent{
+			ID:         eventID,
+			Created:    listenedAt,
+			EventType:  "listen",
+			Hidden:     false,
+			UserName:   friend,
+			ListenedAt: listenedAt,
+			PlayingNow: playingNow,
+			TrackMetadata: ListenBrainzSocialTrackMetadata{
+				ArtistName:  artistName,
+				TrackName:   trackName,
+				ReleaseName: strings.TrimSpace(track.Album.Name),
+				AdditionalInfo: ListenBrainzSocialAdditionalInfo{
+					MusicService:     "last.fm",
+					MusicServiceName: "Last.fm",
+					RecordingMBID:    strings.TrimSpace(track.MBID),
+				},
+			},
+		})
+	}
+
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].ListenedAt == events[j].ListenedAt {
+			return events[i].ID > events[j].ID
+		}
+		return events[i].ListenedAt > events[j].ListenedAt
+	})
+
+	if len(events) > count && count > 0 {
+		return events[:count], nil
+	}
+
+	return events, nil
+}

--- a/lastfm_test.go
+++ b/lastfm_test.go
@@ -1,0 +1,431 @@
+package main
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestSignLastFmParams(t *testing.T) {
+	t.Parallel()
+
+	params := map[string]string{
+		"api_key": "api-key",
+		"artist":  "Test Artist",
+		"method":  "track.updateNowPlaying",
+		"sk":      "session-key",
+		"track":   "Test Track",
+	}
+
+	got := signLastFmParams(params, "shared-secret")
+	wantBytes := md5.Sum([]byte("api_keyapi-keyartistTest Artistmethodtrack.updateNowPlayingsksession-keytrackTest Trackshared-secret"))
+	want := hex.EncodeToString(wantBytes[:])
+	if got != want {
+		t.Fatalf("signLastFmParams() = %q, want %q", got, want)
+	}
+}
+
+func TestSubmitLastFm(t *testing.T) {
+	originalBaseURL := lastFmAPIBaseURL
+	t.Cleanup(func() {
+		lastFmAPIBaseURL = originalBaseURL
+	})
+
+	t.Run("submits now playing and scrobble payloads", func(t *testing.T) {
+		requestBodies := make([]url.Values, 0, 2)
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			if request.Method != http.MethodPost {
+				t.Fatalf("request method = %s, want %s", request.Method, http.MethodPost)
+			}
+
+			rawBody, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("ReadAll(request.Body) error = %v", err)
+			}
+
+			values, err := url.ParseQuery(string(rawBody))
+			if err != nil {
+				t.Fatalf("ParseQuery(request.Body) error = %v", err)
+			}
+
+			requestBodies = append(requestBodies, values)
+			writer.Header().Set("Content-Type", "text/xml; charset=utf-8")
+			_, _ = writer.Write([]byte("<lfm status=\"ok\"></lfm>"))
+		}))
+		defer server.Close()
+
+		lastFmAPIBaseURL = server.URL
+		app := &App{
+			settingsLoaded: true,
+			settings: AppSettings{
+				LastFmAPIKey:     " api-key ",
+				LastFmAPISecret:  " shared-secret ",
+				LastFmSessionKey: " session-key ",
+			},
+		}
+
+		nowPlayingMetadata := LastFmTrackMetadata{
+			ArtistName:      "Test Artist",
+			TrackName:       "Test Track",
+			ReleaseName:     "Test Album",
+			AlbumArtist:     "Album Artist",
+			TrackNumber:     "03/10",
+			RecordingMBID:   "recording-mbid",
+			DurationSeconds: 321,
+		}
+		if err := app.SubmitLastFm("playing_now", nowPlayingMetadata, 0); err != nil {
+			t.Fatalf("SubmitLastFm(playing_now) error = %v", err)
+		}
+
+		scrobbleMetadata := LastFmTrackMetadata{
+			ArtistName:    "Second Artist",
+			TrackName:     "Second Track",
+			ReleaseName:   "Second Album",
+			TrackNumber:   "7",
+			RecordingMBID: "second-recording-mbid",
+		}
+		if err := app.SubmitLastFm("single", scrobbleMetadata, 1710000000); err != nil {
+			t.Fatalf("SubmitLastFm(single) error = %v", err)
+		}
+
+		if len(requestBodies) != 2 {
+			t.Fatalf("request count = %d, want 2", len(requestBodies))
+		}
+
+		nowPlayingBody := requestBodies[0]
+		if got := nowPlayingBody.Get("method"); got != "track.updateNowPlaying" {
+			t.Fatalf("now-playing method = %q, want %q", got, "track.updateNowPlaying")
+		}
+		if got := nowPlayingBody.Get("artist"); got != "Test Artist" {
+			t.Fatalf("now-playing artist = %q, want %q", got, "Test Artist")
+		}
+		if got := nowPlayingBody.Get("track"); got != "Test Track" {
+			t.Fatalf("now-playing track = %q, want %q", got, "Test Track")
+		}
+		if got := nowPlayingBody.Get("album"); got != "Test Album" {
+			t.Fatalf("now-playing album = %q, want %q", got, "Test Album")
+		}
+		if got := nowPlayingBody.Get("albumArtist"); got != "Album Artist" {
+			t.Fatalf("now-playing albumArtist = %q, want %q", got, "Album Artist")
+		}
+		if got := nowPlayingBody.Get("trackNumber"); got != "3" {
+			t.Fatalf("now-playing trackNumber = %q, want %q", got, "3")
+		}
+		if got := nowPlayingBody.Get("mbid"); got != "recording-mbid" {
+			t.Fatalf("now-playing mbid = %q, want %q", got, "recording-mbid")
+		}
+		if got := nowPlayingBody.Get("duration"); got != "321" {
+			t.Fatalf("now-playing duration = %q, want %q", got, "321")
+		}
+		if got := nowPlayingBody.Get("timestamp"); got != "" {
+			t.Fatalf("now-playing timestamp = %q, want empty", got)
+		}
+		if got := nowPlayingBody.Get("api_sig"); got == "" {
+			t.Fatal("now-playing api_sig should not be empty")
+		}
+
+		scrobbleBody := requestBodies[1]
+		if got := scrobbleBody.Get("method"); got != "track.scrobble" {
+			t.Fatalf("scrobble method = %q, want %q", got, "track.scrobble")
+		}
+		if got := scrobbleBody.Get("timestamp"); got != "1710000000" {
+			t.Fatalf("scrobble timestamp = %q, want %q", got, "1710000000")
+		}
+		if got := scrobbleBody.Get("trackNumber"); got != "7" {
+			t.Fatalf("scrobble trackNumber = %q, want %q", got, "7")
+		}
+	})
+
+	t.Run("returns parsed api errors", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			writer.Header().Set("Content-Type", "text/xml; charset=utf-8")
+			_, _ = writer.Write([]byte("<lfm status=\"failed\"><error code=\"9\">Invalid session key - Please re-authenticate</error></lfm>"))
+		}))
+		defer server.Close()
+
+		lastFmAPIBaseURL = server.URL
+		app := &App{
+			settingsLoaded: true,
+			settings: AppSettings{
+				LastFmAPIKey:     "api-key",
+				LastFmAPISecret:  "shared-secret",
+				LastFmSessionKey: "session-key",
+			},
+		}
+
+		err := app.SubmitLastFm("single", LastFmTrackMetadata{
+			ArtistName: "Test Artist",
+			TrackName:  "Test Track",
+		}, 1710000000)
+		if err == nil {
+			t.Fatal("SubmitLastFm() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "Invalid session key") {
+			t.Fatalf("SubmitLastFm() error = %q, want Last.fm API error", err.Error())
+		}
+	})
+
+	t.Run("requires complete credentials", func(t *testing.T) {
+		app := &App{
+			settingsLoaded: true,
+			settings: AppSettings{
+				LastFmAPIKey:     "api-key",
+				LastFmAPISecret:  "",
+				LastFmSessionKey: "session-key",
+			},
+		}
+
+		err := app.SubmitLastFm("playing_now", LastFmTrackMetadata{
+			ArtistName: "Test Artist",
+			TrackName:  "Test Track",
+		}, 0)
+		if err == nil {
+			t.Fatal("SubmitLastFm() error = nil, want error")
+		}
+		if got, want := err.Error(), "last.fm scrobbling requires an API key, shared secret, and session key"; got != want {
+			t.Fatalf("SubmitLastFm() error = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("suppresses duplicate single scrobbles", func(t *testing.T) {
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			requestCount++
+			writer.Header().Set("Content-Type", "text/xml; charset=utf-8")
+			_, _ = writer.Write([]byte("<lfm status=\"ok\"></lfm>"))
+		}))
+		defer server.Close()
+
+		lastFmAPIBaseURL = server.URL
+		app := &App{
+			settingsLoaded: true,
+			settings: AppSettings{
+				LastFmAPIKey:     "api-key",
+				LastFmAPISecret:  "shared-secret",
+				LastFmSessionKey: "session-key",
+			},
+		}
+
+		metadata := LastFmTrackMetadata{
+			ArtistName:    "Duplicate Artist",
+			TrackName:     "Duplicate Track",
+			ReleaseName:   "Duplicate Album",
+			RecordingMBID: "duplicate-recording-mbid",
+		}
+
+		if err := app.SubmitLastFm("single", metadata, 1710000000); err != nil {
+			t.Fatalf("first SubmitLastFm(single) error = %v", err)
+		}
+		if err := app.SubmitLastFm("single", metadata, 1710000000); err != nil {
+			t.Fatalf("second SubmitLastFm(single) error = %v", err)
+		}
+
+		if requestCount != 1 {
+			t.Fatalf("request count = %d, want 1", requestCount)
+		}
+	})
+
+	t.Run("suppresses near-duplicate single scrobbles with drifted timestamps", func(t *testing.T) {
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			requestCount++
+			writer.Header().Set("Content-Type", "text/xml; charset=utf-8")
+			_, _ = writer.Write([]byte("<lfm status=\"ok\"></lfm>"))
+		}))
+		defer server.Close()
+
+		lastFmAPIBaseURL = server.URL
+		app := &App{
+			settingsLoaded: true,
+			settings: AppSettings{
+				LastFmAPIKey:     "api-key",
+				LastFmAPISecret:  "shared-secret",
+				LastFmSessionKey: "session-key",
+			},
+		}
+
+		metadata := LastFmTrackMetadata{
+			ArtistName:    "Duplicate Artist",
+			TrackName:     "Duplicate Track",
+			ReleaseName:   "Duplicate Album",
+			RecordingMBID: "duplicate-recording-mbid",
+		}
+
+		if err := app.SubmitLastFm("single", metadata, 1710000000); err != nil {
+			t.Fatalf("first SubmitLastFm(single) error = %v", err)
+		}
+		if err := app.SubmitLastFm("single", metadata, 1710000008); err != nil {
+			t.Fatalf("second SubmitLastFm(single) error = %v", err)
+		}
+
+		if requestCount != 1 {
+			t.Fatalf("request count = %d, want 1", requestCount)
+		}
+	})
+
+	t.Run("suppresses duplicate single scrobbles when artist label changes", func(t *testing.T) {
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			requestCount++
+			writer.Header().Set("Content-Type", "text/xml; charset=utf-8")
+			_, _ = writer.Write([]byte("<lfm status=\"ok\"></lfm>"))
+		}))
+		defer server.Close()
+
+		lastFmAPIBaseURL = server.URL
+		app := &App{
+			settingsLoaded: true,
+			settings: AppSettings{
+				LastFmAPIKey:     "api-key",
+				LastFmAPISecret:  "shared-secret",
+				LastFmSessionKey: "session-key",
+			},
+		}
+
+		if err := app.SubmitLastFm("single", LastFmTrackMetadata{
+			ArtistName:    "Masato Kouda",
+			TrackName:     "コメディックスタイル",
+			ReleaseName:   "「魔法戦争」オリジナルサウンドトラック",
+			RecordingMBID: "",
+		}, 1710000100); err != nil {
+			t.Fatalf("first SubmitLastFm(single) error = %v", err)
+		}
+
+		if err := app.SubmitLastFm("single", LastFmTrackMetadata{
+			ArtistName:    "甲田雅人",
+			TrackName:     "コメディックスタイル",
+			ReleaseName:   "「魔法戦争」オリジナルサウンドトラック",
+			RecordingMBID: "",
+		}, 1710000106); err != nil {
+			t.Fatalf("second SubmitLastFm(single) error = %v", err)
+		}
+
+		if requestCount != 1 {
+			t.Fatalf("request count = %d, want 1", requestCount)
+		}
+	})
+}
+
+func TestGetLastFmRequestToken(t *testing.T) {
+	originalBaseURL := lastFmAPIBaseURL
+	t.Cleanup(func() {
+		lastFmAPIBaseURL = originalBaseURL
+	})
+
+	t.Run("returns token from successful response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			rawBody, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("ReadAll(request.Body) error = %v", err)
+			}
+
+			values, err := url.ParseQuery(string(rawBody))
+			if err != nil {
+				t.Fatalf("ParseQuery(request.Body) error = %v", err)
+			}
+
+			if got := values.Get("method"); got != "auth.getToken" {
+				t.Fatalf("method = %q, want %q", got, "auth.getToken")
+			}
+			if got := values.Get("api_key"); got != "api-key" {
+				t.Fatalf("api_key = %q, want %q", got, "api-key")
+			}
+			if values.Get("api_sig") == "" {
+				t.Fatal("api_sig should not be empty")
+			}
+
+			writer.Header().Set("Content-Type", "text/xml; charset=utf-8")
+			_, _ = writer.Write([]byte("<lfm status=\"ok\"><token>request-token</token></lfm>"))
+		}))
+		defer server.Close()
+
+		lastFmAPIBaseURL = server.URL
+		app := &App{}
+
+		token, err := app.GetLastFmRequestToken("api-key", "shared-secret")
+		if err != nil {
+			t.Fatalf("GetLastFmRequestToken() error = %v", err)
+		}
+		if token != "request-token" {
+			t.Fatalf("GetLastFmRequestToken() = %q, want %q", token, "request-token")
+		}
+	})
+
+	t.Run("returns explicit api error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			writer.Header().Set("Content-Type", "text/xml; charset=utf-8")
+			_, _ = writer.Write([]byte("<lfm status=\"failed\"><error code=\"10\">Invalid API key</error></lfm>"))
+		}))
+		defer server.Close()
+
+		lastFmAPIBaseURL = server.URL
+		app := &App{}
+
+		_, err := app.GetLastFmRequestToken("api-key", "shared-secret")
+		if err == nil {
+			t.Fatal("GetLastFmRequestToken() error = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "Invalid API key") {
+			t.Fatalf("GetLastFmRequestToken() error = %q, want API error message", err.Error())
+		}
+	})
+}
+
+func TestGetLastFmSessionKey(t *testing.T) {
+	originalBaseURL := lastFmAPIBaseURL
+	t.Cleanup(func() {
+		lastFmAPIBaseURL = originalBaseURL
+	})
+
+	t.Run("returns session key from successful response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			rawBody, err := io.ReadAll(request.Body)
+			if err != nil {
+				t.Fatalf("ReadAll(request.Body) error = %v", err)
+			}
+
+			values, err := url.ParseQuery(string(rawBody))
+			if err != nil {
+				t.Fatalf("ParseQuery(request.Body) error = %v", err)
+			}
+
+			if got := values.Get("method"); got != "auth.getSession" {
+				t.Fatalf("method = %q, want %q", got, "auth.getSession")
+			}
+			if got := values.Get("token"); got != "request-token" {
+				t.Fatalf("token = %q, want %q", got, "request-token")
+			}
+
+			writer.Header().Set("Content-Type", "text/xml; charset=utf-8")
+			_, _ = writer.Write([]byte("<lfm status=\"ok\"><session><name>user</name><key>session-key</key></session></lfm>"))
+		}))
+		defer server.Close()
+
+		lastFmAPIBaseURL = server.URL
+		app := &App{}
+
+		sessionKey, err := app.GetLastFmSessionKey("api-key", "shared-secret", "request-token")
+		if err != nil {
+			t.Fatalf("GetLastFmSessionKey() error = %v", err)
+		}
+		if sessionKey != "session-key" {
+			t.Fatalf("GetLastFmSessionKey() = %q, want %q", sessionKey, "session-key")
+		}
+	})
+
+	t.Run("validates required request token", func(t *testing.T) {
+		app := &App{}
+		_, err := app.GetLastFmSessionKey("api-key", "shared-secret", "")
+		if err == nil {
+			t.Fatal("GetLastFmSessionKey() error = nil, want error")
+		}
+		if got, want := err.Error(), "last.fm session exchange requires a request token"; got != want {
+			t.Fatalf("GetLastFmSessionKey() error = %q, want %q", got, want)
+		}
+	})
+}

--- a/settings.go
+++ b/settings.go
@@ -51,6 +51,9 @@ type AppSettings struct {
 	LibraryPath                            string                   `json:"libraryPath,omitempty"`
 	FFmpegPath                             string                   `json:"ffmpegPath,omitempty"`
 	ListenBrainzUserToken                  string                   `json:"listenBrainzUserToken"`
+	LastFmAPIKey                           string                   `json:"lastFmApiKey"`
+	LastFmAPISecret                        string                   `json:"lastFmApiSecret"`
+	LastFmSessionKey                       string                   `json:"lastFmSessionKey"`
 	ScrobbleFilterMode                     string                   `json:"scrobbleFilterMode,omitempty"`
 	ScrobbleRules                          []ScrobbleRule           `json:"scrobbleRules,omitempty"`
 	ScrobbleFolders                        []string                 `json:"scrobbleFolders,omitempty"`
@@ -566,6 +569,9 @@ func normalizeLibraryFolders(folders []AppLibraryFolder, legacyPath string, lega
 
 func normalizeAppSettings(settings AppSettings) AppSettings {
 	token := strings.TrimSpace(settings.ListenBrainzUserToken)
+	lastFmAPIKey := strings.TrimSpace(settings.LastFmAPIKey)
+	lastFmAPISecret := strings.TrimSpace(settings.LastFmAPISecret)
+	lastFmSessionKey := strings.TrimSpace(settings.LastFmSessionKey)
 	playbackOrder := normalizePlaybackOrder(settings.PlaybackOrder)
 	libraryFolders := normalizeLibraryFolders(settings.LibraryFolders, settings.LibraryPath, settings.ReleaseDepth)
 	coverArtPriority := normalizeCoverArtPriority(settings.CoverArtPriority)
@@ -609,6 +615,9 @@ func normalizeAppSettings(settings AppSettings) AppSettings {
 		LibraryPath:                            legacyLibraryPath,
 		FFmpegPath:                             normalizeFFmpegPath(settings.FFmpegPath),
 		ListenBrainzUserToken:                  token,
+		LastFmAPIKey:                           lastFmAPIKey,
+		LastFmAPISecret:                        lastFmAPISecret,
+		LastFmSessionKey:                       lastFmSessionKey,
 		ScrobbleFilterMode:                     scrobbleFilterMode,
 		ScrobbleRules:                          scrobbleRules,
 		MusicBrainzServerURL:                   musicBrainzServerURL,

--- a/settings_test.go
+++ b/settings_test.go
@@ -357,6 +357,9 @@ func TestNormalizeScrobbleFilterMode(t *testing.T) {
 
 func TestNormalizeAppSettingsScrobbleRules(t *testing.T) {
 	settings := normalizeAppSettings(AppSettings{
+		LastFmAPIKey:       " api-key ",
+		LastFmAPISecret:    " shared-secret ",
+		LastFmSessionKey:   " session-key ",
 		ScrobbleFilterMode: "whitelist",
 		ScrobbleRules: []ScrobbleRule{
 			{Field: scrobbleRuleFieldTrackArtist, Operator: scrobbleRuleOperatorRegex, Value: " /foo/i "},
@@ -370,6 +373,10 @@ func TestNormalizeAppSettingsScrobbleRules(t *testing.T) {
 
 	if settings.ScrobbleFilterMode != "whitelist" {
 		t.Fatalf("ScrobbleFilterMode = %q, want %q", settings.ScrobbleFilterMode, "whitelist")
+	}
+
+	if settings.LastFmAPIKey != "api-key" || settings.LastFmAPISecret != "shared-secret" || settings.LastFmSessionKey != "session-key" {
+		t.Fatalf("Last.fm credentials = (%q, %q, %q), want trimmed values", settings.LastFmAPIKey, settings.LastFmAPISecret, settings.LastFmSessionKey)
 	}
 
 	if len(settings.ScrobbleRules) != 3 {


### PR DESCRIPTION
Refines the Last.fm integration across scrobbling, social feed aggregation, and frontend UX.

## What changed
- Added robust Last.fm scrobbling support and auth helpers:
  - Request token/session key flow for desktop auth
  - Last.fm submit handling for now-playing + scrobble events
  - Improved dedupe logic to prevent duplicate scrobbles
- Expanded settings support for Last.fm credentials:
  - API key, shared secret, session key persistence/normalization
  - Added “Fetch” flow support for session key acquisition
- Integrated Last.fm into Social tab alongside ListenBrainz:
  - Backend endpoints for Last.fm following + recent tracks
  - Frontend merged social feed/following from both providers
  - Provider-aware rendering updates (including Last.fm icon)
  - Clickable usernames opening provider profile pages
  - Removed social feed badges for cleaner card layout
- Refactored request scheduling:
  - Extracted Last.fm scheduling into dedicated utility module
  - Added dedicated tests for Last.fm scheduler behavior
- Updated typings/bindings and tests to cover new functionality.