### PR TITLE
Partially reduce resource usage for localized library updates

### DIFF
--- a/app.go
+++ b/app.go
@@ -68,6 +68,7 @@ type libraryEventWatcher interface {
 	Events() <-chan fsnotify.Event
 	Errors() <-chan error
 	HandleCreatePath(path string)
+	DebounceDuration() time.Duration
 	IsClosed() bool
 }
 
@@ -117,6 +118,9 @@ type appLibraryIndexState struct {
 	folderEntriesByFolder         map[string][]LibraryBrowserEntry
 	folderChildPathsByFolder      map[string][]string
 	trackFilesByFolder            map[string][]LibraryIndexedFile
+	directTextEntriesByFolder     map[string][]LibraryBrowserEntry
+	directImageEntriesByFolder    map[string][]LibraryBrowserEntry
+	folderModifiedAtByPath        map[string]int64
 	searchFolderEntries           []LibraryBrowserEntry
 	searchTrackEntries            []LibraryBrowserEntry
 	searchTextEntries             []LibraryBrowserEntry
@@ -132,10 +136,13 @@ type appLibraryIndexState struct {
 }
 
 type appLibraryDatabaseState struct {
-	mu     sync.Mutex
-	wakeCh chan struct{}
-	stopCh chan struct{}
-	doneCh chan struct{}
+	mu                             sync.Mutex
+	wakeCh                         chan struct{}
+	stopCh                         chan struct{}
+	doneCh                         chan struct{}
+	pendingFullSnapshot            bool
+	pendingIncrementalTotalEntries int
+	pendingIncrementalChanges      []preparedIncrementalLibraryChange
 }
 
 type appLibraryWatcherState struct {

--- a/app.go
+++ b/app.go
@@ -63,6 +63,14 @@ type appWatcherState struct {
 	mediaKeys appMediaKeyWatcherState
 }
 
+type libraryEventWatcher interface {
+	Close() error
+	Events() <-chan fsnotify.Event
+	Errors() <-chan error
+	HandleCreatePath(path string)
+	IsClosed() bool
+}
+
 type appLibraryState struct {
 	appLibraryContentState
 	appTrackTagsCacheState
@@ -132,7 +140,7 @@ type appLibraryDatabaseState struct {
 
 type appLibraryWatcherState struct {
 	mu         sync.Mutex
-	watcher    *fsnotify.Watcher
+	watcher    libraryEventWatcher
 	stopCh     chan struct{}
 	generation atomic.Uint64
 }

--- a/app_library_files_db.go
+++ b/app_library_files_db.go
@@ -181,6 +181,52 @@ func (a *App) notifyLibraryFilesDatabaseWorker() {
 		return
 	}
 
+	databaseState := a.libraryDatabaseState()
+	databaseState.mu.Lock()
+	databaseState.pendingFullSnapshot = true
+	databaseState.pendingIncrementalChanges = nil
+	databaseState.pendingIncrementalTotalEntries = 0
+	databaseState.mu.Unlock()
+
+	wakeCh := a.ensureLibraryFilesDatabaseWorker()
+	select {
+	case wakeCh <- struct{}{}:
+	default:
+	}
+}
+
+func clonePreparedIncrementalLibraryChanges(changes []preparedIncrementalLibraryChange) []preparedIncrementalLibraryChange {
+	if len(changes) == 0 {
+		return nil
+	}
+
+	cloned := make([]preparedIncrementalLibraryChange, len(changes))
+	for index, change := range changes {
+		cloned[index] = preparedIncrementalLibraryChange{
+			root:       change.root,
+			targetPath: change.targetPath,
+			trackFiles: append([]LibraryIndexedFile(nil), change.trackFiles...),
+			textFiles:  append([]LibraryIndexedFile(nil), change.textFiles...),
+			imageFiles: append([]LibraryIndexedFile(nil), change.imageFiles...),
+		}
+	}
+
+	return cloned
+}
+
+func (a *App) notifyLibraryFilesDatabaseWorkerIncremental(changes []preparedIncrementalLibraryChange, totalEntries int) {
+	if !a.localLibraryFilesDatabaseEnabled() || len(changes) == 0 {
+		return
+	}
+
+	databaseState := a.libraryDatabaseState()
+	databaseState.mu.Lock()
+	if !databaseState.pendingFullSnapshot {
+		databaseState.pendingIncrementalChanges = append(databaseState.pendingIncrementalChanges, clonePreparedIncrementalLibraryChanges(changes)...)
+		databaseState.pendingIncrementalTotalEntries = totalEntries
+	}
+	databaseState.mu.Unlock()
+
 	wakeCh := a.ensureLibraryFilesDatabaseWorker()
 	select {
 	case wakeCh <- struct{}{}:
@@ -196,6 +242,9 @@ func (a *App) stopLibraryFilesDatabaseWorker() {
 	databaseState.wakeCh = nil
 	databaseState.stopCh = nil
 	databaseState.doneCh = nil
+	databaseState.pendingFullSnapshot = false
+	databaseState.pendingIncrementalChanges = nil
+	databaseState.pendingIncrementalTotalEntries = 0
 	databaseState.mu.Unlock()
 
 	if stopCh == nil || doneCh == nil {
@@ -204,6 +253,29 @@ func (a *App) stopLibraryFilesDatabaseWorker() {
 
 	close(stopCh)
 	<-doneCh
+}
+
+func (a *App) dequeueLibraryFilesDatabaseWork() (bool, []preparedIncrementalLibraryChange, int) {
+	databaseState := a.libraryDatabaseState()
+	databaseState.mu.Lock()
+	defer databaseState.mu.Unlock()
+
+	if databaseState.pendingFullSnapshot {
+		databaseState.pendingFullSnapshot = false
+		databaseState.pendingIncrementalChanges = nil
+		databaseState.pendingIncrementalTotalEntries = 0
+		return true, nil, 0
+	}
+
+	if len(databaseState.pendingIncrementalChanges) == 0 {
+		return false, nil, 0
+	}
+
+	changes := databaseState.pendingIncrementalChanges
+	totalEntries := databaseState.pendingIncrementalTotalEntries
+	databaseState.pendingIncrementalChanges = nil
+	databaseState.pendingIncrementalTotalEntries = 0
+	return false, changes, totalEntries
 }
 
 func (a *App) runLibraryFilesDatabaseWorker(wakeCh <-chan struct{}, stopCh <-chan struct{}, doneCh chan<- struct{}) {
@@ -217,20 +289,34 @@ func (a *App) runLibraryFilesDatabaseWorker(wakeCh <-chan struct{}, stopCh <-cha
 		}
 
 		for {
-			snapshot, ok := a.snapshotLibraryFilesDatabaseState()
-			if !ok {
-				select {
-				case <-stopCh:
-					return
-				case <-time.After(250 * time.Millisecond):
-					continue
-				}
+			fullSnapshot, incrementalChanges, totalEntries := a.dequeueLibraryFilesDatabaseWork()
+			if !fullSnapshot && len(incrementalChanges) == 0 {
+				break
 			}
 
-			if err := writeLibraryFilesDatabaseSnapshotToSQLite(a.libraryFilesDatabasePath(), snapshot); err != nil {
-				logpkg.Printf("failed to persist library files database: %v", err)
+			if fullSnapshot {
+				snapshot, ok := a.snapshotLibraryFilesDatabaseState()
+				if !ok {
+					databaseState := a.libraryDatabaseState()
+					databaseState.mu.Lock()
+					databaseState.pendingFullSnapshot = true
+					databaseState.mu.Unlock()
+					select {
+					case <-stopCh:
+						return
+					case <-time.After(250 * time.Millisecond):
+						continue
+					}
+				}
+
+				if err := writeLibraryFilesDatabaseSnapshotToSQLite(a.libraryFilesDatabasePath(), snapshot); err != nil {
+					logpkg.Printf("failed to persist library files database: %v", err)
+				}
+			} else if len(incrementalChanges) > 0 {
+				if err := writeLibraryFilesDatabaseIncrementalChangesToSQLite(a.libraryFilesDatabasePath(), incrementalChanges, totalEntries); err != nil {
+					logpkg.Printf("failed to persist incremental library files database changes: %v", err)
+				}
 			}
-			break
 		}
 
 		for {
@@ -371,7 +457,6 @@ func (a *App) startLibraryFilesRefreshAsync(roots []libraryRootConfig, expectedS
 		if generationState.libraryScanGeneration.Load() == expectedScanGeneration {
 			indexState.libraryFileHydrationPending = false
 			indexState.libraryFolderEntriesCache = nil
-			a.maybeStartLibraryDerivedIndexRebuildLocked()
 			shouldEmitUpdate = true
 			payload = compactLibraryScanResult(contentState.libraryScan)
 		}

--- a/app_library_files_db_sqlite.go
+++ b/app_library_files_db_sqlite.go
@@ -41,6 +41,44 @@ type sqliteExecRunner interface {
 	Exec(query string, args ...any) (sql.Result, error)
 }
 
+func libraryFilesDatabaseRelativePath(entry LibraryIndexedFile) string {
+	relativePath := strings.TrimSpace(entry.RelativePath)
+	if entry.RootName != "" {
+		prefix := entry.RootName + "/"
+		if relativePath == entry.RootName {
+			relativePath = ""
+		} else if strings.HasPrefix(relativePath, prefix) {
+			relativePath = strings.TrimPrefix(relativePath, prefix)
+		}
+	}
+
+	return relativePath
+}
+
+func writeLibraryFilesDatabaseEntries(runner sqliteExecRunner, kind string, entries []LibraryIndexedFile) error {
+	for _, entry := range entries {
+		relativePath := libraryFilesDatabaseRelativePath(entry)
+		if strings.TrimSpace(relativePath) == "" {
+			continue
+		}
+
+		modUnixNs := entry.ModifiedAtMs * int64(time.Millisecond)
+		if _, err := runner.Exec(
+			`INSERT INTO files (path, root_path, relative_path, kind, size, mod_unix_ns) VALUES (?, ?, ?, ?, ?, ?)`,
+			entry.Path,
+			entry.RootPath,
+			relativePath,
+			kind,
+			int64(0),
+			modUnixNs,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 var libraryFilesSQLiteSchemaStatements = []string{
 	`CREATE TABLE IF NOT EXISTS meta (
 		key TEXT PRIMARY KEY,
@@ -251,53 +289,13 @@ func writeLibraryFilesDatabaseSnapshotToSQLite(path string, snapshot libraryFile
 		}
 	}
 
-	writeEntries := func(kind string, entries []LibraryIndexedFile) error {
-		for _, entry := range entries {
-			relativePath := strings.TrimSpace(entry.RelativePath)
-			if entry.RootName != "" {
-				prefix := entry.RootName + "/"
-				if relativePath == entry.RootName {
-					relativePath = ""
-				} else if strings.HasPrefix(relativePath, prefix) {
-					relativePath = strings.TrimPrefix(relativePath, prefix)
-				}
-			}
-			if strings.TrimSpace(relativePath) == "" {
-				continue
-			}
-
-			var size int64
-			modUnixNs := entry.ModifiedAtMs * int64(time.Millisecond)
-			if info, statErr := os.Stat(entry.Path); statErr == nil {
-				size = info.Size()
-				if modUnixNs <= 0 {
-					modUnixNs = info.ModTime().UnixNano()
-				}
-			}
-
-			if _, err := transaction.Exec(
-				`INSERT INTO files (path, root_path, relative_path, kind, size, mod_unix_ns) VALUES (?, ?, ?, ?, ?, ?)`,
-				entry.Path,
-				entry.RootPath,
-				relativePath,
-				kind,
-				size,
-				modUnixNs,
-			); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
-
-	if err := writeEntries("track", snapshot.TrackFiles); err != nil {
+	if err := writeLibraryFilesDatabaseEntries(transaction, "track", snapshot.TrackFiles); err != nil {
 		return err
 	}
-	if err := writeEntries("text-file", snapshot.TextFiles); err != nil {
+	if err := writeLibraryFilesDatabaseEntries(transaction, "text-file", snapshot.TextFiles); err != nil {
 		return err
 	}
-	if err := writeEntries("image-file", snapshot.ImageFiles); err != nil {
+	if err := writeLibraryFilesDatabaseEntries(transaction, "image-file", snapshot.ImageFiles); err != nil {
 		return err
 	}
 
@@ -306,6 +304,88 @@ func writeLibraryFilesDatabaseSnapshotToSQLite(path string, snapshot libraryFile
 	}
 	committed = true
 
+	return nil
+}
+
+func writeLibraryFilesDatabaseIncrementalChangesToSQLite(path string, changes []preparedIncrementalLibraryChange, totalEntries int) error {
+	if len(changes) == 0 {
+		return nil
+	}
+
+	database, err := openLibraryFilesSQLite(path)
+	if err != nil {
+		return err
+	}
+	defer database.Close()
+
+	if err := initializeLibraryFilesSQLite(database); err != nil {
+		return err
+	}
+
+	transaction, err := database.Begin()
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		_ = transaction.Rollback()
+	}()
+
+	if _, err := transaction.Exec(`INSERT OR REPLACE INTO meta (key, value) VALUES ('version', ?)`, strconv.Itoa(libraryFilesDatabaseVersion)); err != nil {
+		return err
+	}
+	if totalEntries >= 0 {
+		if _, err := transaction.Exec(`INSERT OR REPLACE INTO meta (key, value) VALUES ('total_entries', ?)`, strconv.Itoa(totalEntries)); err != nil {
+			return err
+		}
+	}
+
+	for _, change := range changes {
+		_, relativeTargetPath, ok := folderAndRelative(change.root.Path, change.targetPath)
+		if !ok {
+			continue
+		}
+		relativeTargetPath, ok = normalizeLibraryRelativePath(relativeTargetPath)
+		if !ok {
+			continue
+		}
+
+		if _, err := transaction.Exec(
+			`INSERT OR REPLACE INTO roots (path, release_depth) VALUES (?, ?)`,
+			change.root.Path,
+			change.root.ReleaseDepth,
+		); err != nil {
+			return err
+		}
+
+		deleteArgs := []any{change.root.Path}
+		deleteQuery := `DELETE FROM files WHERE root_path = ?`
+		if relativeTargetPath != "" {
+			deleteQuery += ` AND (relative_path = ? OR relative_path LIKE ?)`
+			deleteArgs = append(deleteArgs, relativeTargetPath, relativeTargetPath+`/%`)
+		}
+		if _, err := transaction.Exec(deleteQuery, deleteArgs...); err != nil {
+			return err
+		}
+
+		if err := writeLibraryFilesDatabaseEntries(transaction, "track", change.trackFiles); err != nil {
+			return err
+		}
+		if err := writeLibraryFilesDatabaseEntries(transaction, "text-file", change.textFiles); err != nil {
+			return err
+		}
+		if err := writeLibraryFilesDatabaseEntries(transaction, "image-file", change.imageFiles); err != nil {
+			return err
+		}
+	}
+
+	if err := transaction.Commit(); err != nil {
+		return err
+	}
+	committed = true
 	return nil
 }
 

--- a/app_library_files_db_test.go
+++ b/app_library_files_db_test.go
@@ -47,6 +47,84 @@ func TestLibraryFilesDatabaseSnapshotRoundTrip(t *testing.T) {
 	}
 }
 
+func TestLibraryFilesDatabaseIncrementalChangesUpdateSubtree(t *testing.T) {
+	fixture := createLibraryTestFixture(t)
+	roots := []libraryRootConfig{{Path: fixture.rootOne, Name: "Library One", ReleaseDepth: 0}, {Path: fixture.rootTwo, Name: "Library Two", ReleaseDepth: 0}}
+	snapshot := libraryFilesDatabaseSnapshot{
+		Roots:        roots,
+		TotalEntries: 6,
+		TrackFiles: []LibraryIndexedFile{
+			{Name: "01 Intro.flac", Path: fixture.trackOne, RelativePath: "Library One/Artist One/Album One/01 Intro.flac", FolderPath: "Library One/Artist One/Album One", RootPath: fixture.rootOne, RootName: "Library One"},
+			{Name: "02 Outro.flac", Path: fixture.trackTwo, RelativePath: "Library Two/Artist Two/Album Two/02 Outro.flac", FolderPath: "Library Two/Artist Two/Album Two", RootPath: fixture.rootTwo, RootName: "Library Two"},
+		},
+		TextFiles: []LibraryIndexedFile{{Name: "notes.txt", Path: fixture.noteOne, RelativePath: "Library One/Artist One/Album One/notes.txt", FolderPath: "Library One/Artist One/Album One", RootPath: fixture.rootOne, RootName: "Library One"}},
+		ImageFiles: []LibraryIndexedFile{
+			{Name: "cover.jpg", Path: fixture.coverOne, RelativePath: "Library One/Artist One/Album One/cover.jpg", FolderPath: "Library One/Artist One/Album One", RootPath: fixture.rootOne, RootName: "Library One"},
+			{Name: "folder.jpg", Path: fixture.folderCoverOne, RelativePath: "Library One/Artist One/Album One/folder.jpg", FolderPath: "Library One/Artist One/Album One", RootPath: fixture.rootOne, RootName: "Library One"},
+			{Name: "booklet.png", Path: fixture.imageTwo, RelativePath: "Library Two/Artist Two/Album Two/booklet.png", FolderPath: "Library Two/Artist Two/Album Two", RootPath: fixture.rootTwo, RootName: "Library Two"},
+		},
+	}
+
+	databasePath := filepath.Join(t.TempDir(), libraryFilesDatabaseFileName)
+	if err := writeLibraryFilesDatabaseSnapshotToSQLite(databasePath, snapshot); err != nil {
+		t.Fatalf("writeLibraryFilesDatabaseSnapshotToSQLite() error = %v", err)
+	}
+
+	bonusTrack := filepath.Join(fixture.albumOneFolder, "03 Bonus.flac")
+	writeTestFile(t, bonusTrack, "bonus track")
+	change := preparedIncrementalLibraryChange{
+		root:       roots[0],
+		targetPath: fixture.albumOneFolder,
+		trackFiles: []LibraryIndexedFile{
+			{Name: "01 Intro.flac", Path: fixture.trackOne, RelativePath: "Library One/Artist One/Album One/01 Intro.flac", FolderPath: "Library One/Artist One/Album One", RootPath: fixture.rootOne, RootName: "Library One"},
+			{Name: "03 Bonus.flac", Path: bonusTrack, RelativePath: "Library One/Artist One/Album One/03 Bonus.flac", FolderPath: "Library One/Artist One/Album One", RootPath: fixture.rootOne, RootName: "Library One"},
+		},
+		imageFiles: []LibraryIndexedFile{{Name: "folder.jpg", Path: fixture.folderCoverOne, RelativePath: "Library One/Artist One/Album One/folder.jpg", FolderPath: "Library One/Artist One/Album One", RootPath: fixture.rootOne, RootName: "Library One"}},
+	}
+
+	if err := writeLibraryFilesDatabaseIncrementalChangesToSQLite(databasePath, []preparedIncrementalLibraryChange{change}, 5); err != nil {
+		t.Fatalf("writeLibraryFilesDatabaseIncrementalChangesToSQLite() error = %v", err)
+	}
+
+	loaded, ok := loadLibraryFilesDatabaseSnapshot(databasePath, roots)
+	if !ok {
+		t.Fatal("loadLibraryFilesDatabaseSnapshot() = false, want true")
+	}
+
+	result := loaded.scanResult()
+	if result.TotalEntries != 5 || result.TrackCount != 3 || result.TextFileCount != 0 || result.ImageFileCount != 2 {
+		t.Fatalf("incremental database scan result = %#v, want counts 5/3/0/2", result)
+	}
+	if got := result.CoverPathByFolder["library one/artist one/album one"]; got != fixture.folderCoverOne {
+		t.Fatalf("loaded cover path after incremental update = %q, want %q", got, fixture.folderCoverOne)
+	}
+
+	trackPaths := make(map[string]struct{}, len(result.TrackFiles))
+	for _, entry := range result.TrackFiles {
+		trackPaths[entry.Path] = struct{}{}
+	}
+	if _, ok := trackPaths[fixture.trackOne]; !ok {
+		t.Fatalf("track %q missing after incremental update", fixture.trackOne)
+	}
+	if _, ok := trackPaths[bonusTrack]; !ok {
+		t.Fatalf("track %q missing after incremental update", bonusTrack)
+	}
+	if _, ok := trackPaths[fixture.trackTwo]; !ok {
+		t.Fatalf("unrelated track %q missing after incremental update", fixture.trackTwo)
+	}
+
+	for _, entry := range result.TextFiles {
+		if entry.Path == fixture.noteOne {
+			t.Fatalf("removed text file %q still present after incremental update", fixture.noteOne)
+		}
+	}
+	for _, entry := range result.ImageFiles {
+		if entry.Path == fixture.coverOne {
+			t.Fatalf("removed image file %q still present after incremental update", fixture.coverOne)
+		}
+	}
+}
+
 func TestScanLibraryFoldersDeferredLoadsFromDatabaseBeforeFilesystemRefresh(t *testing.T) {
 	fixture := createLibraryTestFixture(t)
 	app := NewApp()

--- a/app_library_index.go
+++ b/app_library_index.go
@@ -1,21 +1,40 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 )
 
 const librarySearchCacheLimit = 24
 
+type libraryFolderIndexData struct {
+	folderEntriesByFolder      map[string][]LibraryBrowserEntry
+	folderChildPathsByFolder   map[string][]string
+	trackFilesByFolder         map[string][]LibraryIndexedFile
+	directTextEntriesByFolder  map[string][]LibraryBrowserEntry
+	directImageEntriesByFolder map[string][]LibraryBrowserEntry
+	folderModifiedAtByPath     map[string]int64
+	searchFolderEntries        []LibraryBrowserEntry
+}
+
+type librarySearchIndexData struct {
+	searchTrackEntries []LibraryBrowserEntry
+	searchTextEntries  []LibraryBrowserEntry
+	searchImageEntries []LibraryBrowserEntry
+}
+
 type libraryDerivedIndexData struct {
-	folderEntriesByFolder    map[string][]LibraryBrowserEntry
-	folderChildPathsByFolder map[string][]string
-	trackFilesByFolder       map[string][]LibraryIndexedFile
-	searchFolderEntries      []LibraryBrowserEntry
-	searchTrackEntries       []LibraryBrowserEntry
-	searchTextEntries        []LibraryBrowserEntry
-	searchImageEntries       []LibraryBrowserEntry
+	libraryFolderIndexData
+	librarySearchIndexData
+}
+
+type incrementalDerivedIndexUpdate struct {
+	targetFolderPath       string
+	previousSubtreeFolders map[string]struct{}
+	subtreeFolderIndex     libraryFolderIndexData
+	affectedCoverFolders   map[string]struct{}
 }
 
 func (a *App) markLibraryDerivedIndexDirtyLocked() {
@@ -25,7 +44,23 @@ func (a *App) markLibraryDerivedIndexDirtyLocked() {
 	indexState.folderEntriesByFolder = nil
 	indexState.folderChildPathsByFolder = nil
 	indexState.trackFilesByFolder = nil
+	indexState.directTextEntriesByFolder = nil
+	indexState.directImageEntriesByFolder = nil
+	indexState.folderModifiedAtByPath = nil
 	indexState.searchFolderEntries = nil
+	a.invalidateLibrarySearchIndexLocked()
+}
+
+func (a *App) markLibrarySearchIndexDirtyLocked() {
+	indexState := a.libraryIndexState()
+	indexState.libraryDerivedIndexGeneration++
+	indexState.libraryDerivedIndexDirty = true
+	indexState.libraryDerivedIndexBuilding = false
+	a.invalidateLibrarySearchIndexLocked()
+}
+
+func (a *App) invalidateLibrarySearchIndexLocked() {
+	indexState := a.libraryIndexState()
 	indexState.searchTrackEntries = nil
 	indexState.searchTextEntries = nil
 	indexState.searchImageEntries = nil
@@ -35,13 +70,19 @@ func (a *App) markLibraryDerivedIndexDirtyLocked() {
 	indexState.searchLastResults = nil
 }
 
-func (a *App) isLibraryDerivedIndexReadyLocked() bool {
+func (a *App) isLibraryFolderIndexReadyLocked() bool {
 	indexState := a.libraryIndexState()
-	return !indexState.libraryDerivedIndexDirty &&
-		!indexState.libraryDerivedIndexBuilding &&
-		indexState.folderEntriesByFolder != nil &&
+	return indexState.folderEntriesByFolder != nil &&
 		indexState.folderChildPathsByFolder != nil &&
 		indexState.trackFilesByFolder != nil &&
+		indexState.directTextEntriesByFolder != nil &&
+		indexState.directImageEntriesByFolder != nil &&
+		indexState.folderModifiedAtByPath != nil
+}
+
+func (a *App) isLibrarySearchIndexReadyLocked() bool {
+	indexState := a.libraryIndexState()
+	return a.isLibraryFolderIndexReadyLocked() &&
 		indexState.searchFolderEntries != nil &&
 		indexState.searchTrackEntries != nil &&
 		indexState.searchTextEntries != nil &&
@@ -49,80 +90,376 @@ func (a *App) isLibraryDerivedIndexReadyLocked() bool {
 		indexState.searchResultsByQuery != nil
 }
 
-func (a *App) maybeStartLibraryDerivedIndexRebuildLocked() {
-	scanState := a.libraryScanState()
-	contentState := a.libraryContentState()
-	indexState := a.libraryIndexState()
-	if scanState.scanInProgress || indexState.libraryFileHydrationPending || !indexState.libraryDerivedIndexDirty || indexState.libraryDerivedIndexBuilding {
-		return
+func cloneIndexedFiles(entries []LibraryIndexedFile) []LibraryIndexedFile {
+	if len(entries) == 0 {
+		return []LibraryIndexedFile{}
 	}
 
-	generation := indexState.libraryDerivedIndexGeneration
-	trackFiles := make([]LibraryIndexedFile, 0, len(contentState.trackByPath))
-	for _, indexed := range contentState.trackByPath {
-		trackFiles = append(trackFiles, indexed)
-	}
-
-	textFiles := make([]LibraryIndexedFile, 0, len(contentState.textByPath))
-	for _, indexed := range contentState.textByPath {
-		textFiles = append(textFiles, indexed)
-	}
-
-	imageFiles := make([]LibraryIndexedFile, 0, len(contentState.imageByPath))
-	for _, indexed := range contentState.imageByPath {
-		imageFiles = append(imageFiles, indexed)
-	}
-
-	indexState.libraryDerivedIndexBuilding = true
-	a.logRescanEvent(
-		"rebuildLibraryDerivedIndex START (async): %d tracks, %d text, %d images",
-		len(trackFiles),
-		len(textFiles),
-		len(imageFiles),
-	)
-
-	go a.rebuildLibraryDerivedIndexAsync(generation, trackFiles, textFiles, imageFiles)
+	return append([]LibraryIndexedFile(nil), entries...)
 }
 
-func (a *App) rebuildLibraryDerivedIndexAsync(generation uint64, trackFiles []LibraryIndexedFile, textFiles []LibraryIndexedFile, imageFiles []LibraryIndexedFile) {
-	rebuildStartedAt := time.Now()
-	indexData := buildLibraryDerivedIndexData(trackFiles, textFiles, imageFiles)
-	rebuildDurationMs := time.Since(rebuildStartedAt).Seconds() * 1000
-	contentState := a.libraryContentState()
-	scanState := a.libraryScanState()
-	indexState := a.libraryIndexState()
-
-	contentState.indexMu.Lock()
-	defer contentState.indexMu.Unlock()
-
-	if scanState.scanInProgress || generation != indexState.libraryDerivedIndexGeneration {
-		indexState.libraryDerivedIndexBuilding = false
-		a.maybeStartLibraryDerivedIndexRebuildLocked()
-		return
+func cloneBrowserEntries(entries []LibraryBrowserEntry) []LibraryBrowserEntry {
+	if len(entries) == 0 {
+		return []LibraryBrowserEntry{}
 	}
 
-	indexState.folderEntriesByFolder = indexData.folderEntriesByFolder
-	indexState.folderChildPathsByFolder = indexData.folderChildPathsByFolder
-	indexState.trackFilesByFolder = indexData.trackFilesByFolder
-	indexState.searchFolderEntries = indexData.searchFolderEntries
-	indexState.searchTrackEntries = indexData.searchTrackEntries
-	indexState.searchTextEntries = indexData.searchTextEntries
-	indexState.searchImageEntries = indexData.searchImageEntries
-	indexState.searchResultsByQuery = make(map[string][]LibraryBrowserEntry)
-	indexState.searchCacheOrder = make([]string, 0, librarySearchCacheLimit)
-	indexState.searchLastQuery = ""
-	indexState.searchLastResults = nil
-	indexState.libraryDerivedIndexDirty = false
-	indexState.libraryDerivedIndexBuilding = false
+	return append([]LibraryBrowserEntry(nil), entries...)
+}
 
-	a.logRescanEvent(
-		"rebuildLibraryDerivedIndex END: %d folders, %d track files, %d text files, %d images in %.2fms",
-		len(indexData.searchFolderEntries),
-		len(indexData.searchTrackEntries),
-		len(indexData.searchTextEntries),
-		len(indexData.searchImageEntries),
-		rebuildDurationMs,
-	)
+func virtualPathWithinSubtree(rootPath string, candidatePath string) bool {
+	if rootPath == "" {
+		return true
+	}
+
+	return candidatePath == rootPath || strings.HasPrefix(candidatePath, rootPath+"/")
+}
+
+func (a *App) pathHasIndexedContentLocked(path string) bool {
+	contentState := a.libraryContentState()
+	prefix := path + string(filepath.Separator)
+
+	hasIndexedContent := func(indexedByPath map[string]LibraryIndexedFile) bool {
+		for indexedPath := range indexedByPath {
+			if indexedPath == path || strings.HasPrefix(indexedPath, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	return hasIndexedContent(contentState.trackByPath) ||
+		hasIndexedContent(contentState.textByPath) ||
+		hasIndexedContent(contentState.imageByPath)
+}
+
+func (a *App) collectExistingDerivedFoldersInSubtreeLocked(targetFolderPath string) map[string]struct{} {
+	indexState := a.libraryIndexState()
+	folders := make(map[string]struct{})
+	collect := func(values map[string][]LibraryBrowserEntry) {
+		for folderPath := range values {
+			if virtualPathWithinSubtree(targetFolderPath, folderPath) {
+				folders[folderPath] = struct{}{}
+			}
+		}
+	}
+	collectTrackFiles := func(values map[string][]LibraryIndexedFile) {
+		for folderPath := range values {
+			if virtualPathWithinSubtree(targetFolderPath, folderPath) {
+				folders[folderPath] = struct{}{}
+			}
+		}
+	}
+	collect(indexState.folderEntriesByFolder)
+	collectTrackFiles(indexState.trackFilesByFolder)
+	collect(indexState.directTextEntriesByFolder)
+	collect(indexState.directImageEntriesByFolder)
+	for folderPath := range indexState.folderChildPathsByFolder {
+		if virtualPathWithinSubtree(targetFolderPath, folderPath) {
+			folders[folderPath] = struct{}{}
+		}
+	}
+	for folderPath := range indexState.folderModifiedAtByPath {
+		if virtualPathWithinSubtree(targetFolderPath, folderPath) {
+			folders[folderPath] = struct{}{}
+		}
+	}
+	return folders
+}
+
+func libraryFolderPathForIncrementalTarget(root libraryRootConfig, targetPath string) string {
+	absoluteTargetPath, ok := absoluteNormalizedPath(targetPath)
+	if !ok || !pathWithinRoot(root.Path, absoluteTargetPath) {
+		return ""
+	}
+
+	relativePath, err := filepath.Rel(root.Path, absoluteTargetPath)
+	if err != nil {
+		return ""
+	}
+	relativePath = filepath.ToSlash(filepath.Clean(relativePath))
+	if relativePath == "." {
+		relativePath = ""
+	}
+
+	if info, statErr := os.Stat(absoluteTargetPath); statErr == nil && info.IsDir() {
+		return buildVirtualLibraryPath(root.Name, relativePath)
+	}
+
+	parentPath := filepath.ToSlash(filepath.Dir(relativePath))
+	if parentPath == "." {
+		parentPath = ""
+	}
+	return buildVirtualLibraryPath(root.Name, parentPath)
+}
+
+func (a *App) collectIncrementalDerivedIndexUpdateLocked(prepared preparedIncrementalLibraryChange) incrementalDerivedIndexUpdate {
+	update := incrementalDerivedIndexUpdate{
+		previousSubtreeFolders: make(map[string]struct{}),
+		affectedCoverFolders:   make(map[string]struct{}),
+	}
+
+	update.targetFolderPath = libraryFolderPathForIncrementalTarget(prepared.root, prepared.targetPath)
+	update.previousSubtreeFolders = a.collectExistingDerivedFoldersInSubtreeLocked(update.targetFolderPath)
+	update.subtreeFolderIndex = buildLibraryFolderIndexData(prepared.trackFiles, prepared.textFiles, prepared.imageFiles)
+
+	for folderPath := range update.previousSubtreeFolders {
+		update.affectedCoverFolders[folderPath] = struct{}{}
+	}
+	for folderPath := range update.subtreeFolderIndex.directImageEntriesByFolder {
+		if virtualPathWithinSubtree(update.targetFolderPath, folderPath) {
+			update.affectedCoverFolders[folderPath] = struct{}{}
+		}
+	}
+
+	return update
+}
+
+func directTrackEntriesFromFiles(trackFiles []LibraryIndexedFile) []LibraryBrowserEntry {
+	entries := make([]LibraryBrowserEntry, 0, len(trackFiles))
+	for _, indexed := range trackFiles {
+		entries = append(entries, browserEntryFromIndexedFile("track", indexed))
+	}
+	sortBrowserEntriesByName(entries)
+	return entries
+}
+
+func (a *App) bestCoverPathForFolderFromContentLocked(folderPath string) string {
+	contentState := a.libraryContentState()
+	folderKey := strings.ToLower(strings.TrimSpace(folderPath))
+	selectedPriority := 0
+	selectedName := ""
+	selectedPath := ""
+	hasSelection := false
+
+	for _, indexed := range contentState.imageByPath {
+		if strings.ToLower(indexed.FolderPath) != folderKey || !isPreferredCoverImagePath(indexed.Path) {
+			continue
+		}
+
+		name := strings.ToLower(indexed.Name)
+		priority := coverPriority(name)
+		if !hasSelection || priority < selectedPriority || (priority == selectedPriority && name < selectedName) {
+			hasSelection = true
+			selectedPriority = priority
+			selectedName = name
+			selectedPath = indexed.Path
+		}
+	}
+
+	return selectedPath
+}
+
+func appendSortedUniqueChildPath(childPaths []string, childPath string) []string {
+	for _, existing := range childPaths {
+		if existing == childPath {
+			return childPaths
+		}
+	}
+	childPaths = append(childPaths, childPath)
+	sortPathsCaseInsensitive(childPaths)
+	return childPaths
+}
+
+func removeChildPath(childPaths []string, childPath string) []string {
+	for index, existing := range childPaths {
+		if existing != childPath {
+			continue
+		}
+		updated := append([]string(nil), childPaths[:index]...)
+		updated = append(updated, childPaths[index+1:]...)
+		return updated
+	}
+	return childPaths
+}
+
+func parentFolderPath(folderPath string) string {
+	if folderPath == "" {
+		return ""
+	}
+
+	lastSlash := strings.LastIndex(folderPath, "/")
+	if lastSlash < 0 {
+		return ""
+	}
+
+	return folderPath[:lastSlash]
+}
+
+func ancestorFolderPathsBottomUp(folderPath string) []string {
+	ancestors := make([]string, 0, 8)
+	current := folderPath
+	for {
+		ancestors = append(ancestors, current)
+		if current == "" {
+			break
+		}
+		current = parentFolderPath(current)
+	}
+	return ancestors
+}
+
+func (a *App) folderExistsInDerivedIndexLocked(folderPath string) bool {
+	if folderPath == "" {
+		return true
+	}
+
+	indexState := a.libraryIndexState()
+	return len(indexState.trackFilesByFolder[folderPath]) > 0 ||
+		len(indexState.directTextEntriesByFolder[folderPath]) > 0 ||
+		len(indexState.directImageEntriesByFolder[folderPath]) > 0 ||
+		len(indexState.folderChildPathsByFolder[folderPath]) > 0
+}
+
+func (a *App) recomputeFolderModifiedAtFromDerivedIndexLocked(folderPath string) int64 {
+	indexState := a.libraryIndexState()
+	maxModifiedAtMs := int64(0)
+	for _, indexed := range indexState.trackFilesByFolder[folderPath] {
+		if indexed.ModifiedAtMs > maxModifiedAtMs {
+			maxModifiedAtMs = indexed.ModifiedAtMs
+		}
+	}
+	for _, entry := range indexState.directTextEntriesByFolder[folderPath] {
+		if entry.ModifiedAtMs > maxModifiedAtMs {
+			maxModifiedAtMs = entry.ModifiedAtMs
+		}
+	}
+	for _, entry := range indexState.directImageEntriesByFolder[folderPath] {
+		if entry.ModifiedAtMs > maxModifiedAtMs {
+			maxModifiedAtMs = entry.ModifiedAtMs
+		}
+	}
+	for _, childPath := range indexState.folderChildPathsByFolder[folderPath] {
+		if indexState.folderModifiedAtByPath[childPath] > maxModifiedAtMs {
+			maxModifiedAtMs = indexState.folderModifiedAtByPath[childPath]
+		}
+	}
+	return maxModifiedAtMs
+}
+
+func (a *App) buildFolderEntriesFromDerivedCachesLocked(folderPath string) []LibraryBrowserEntry {
+	indexState := a.libraryIndexState()
+	childPaths := indexState.folderChildPathsByFolder[folderPath]
+	entries := make([]LibraryBrowserEntry, 0, len(childPaths)+len(indexState.trackFilesByFolder[folderPath])+len(indexState.directTextEntriesByFolder[folderPath])+len(indexState.directImageEntriesByFolder[folderPath]))
+	for _, childPath := range childPaths {
+		entries = append(entries, folderBrowserEntry(childPath, indexState.folderModifiedAtByPath[childPath]))
+	}
+	entries = append(entries, directTrackEntriesFromFiles(indexState.trackFilesByFolder[folderPath])...)
+	entries = append(entries, cloneBrowserEntries(indexState.directTextEntriesByFolder[folderPath])...)
+	entries = append(entries, cloneBrowserEntries(indexState.directImageEntriesByFolder[folderPath])...)
+	return entries
+}
+
+func folderSetFromFolderIndexData(indexData libraryFolderIndexData, targetFolderPath string) map[string]struct{} {
+	folders := make(map[string]struct{})
+	collectEntries := func(values map[string][]LibraryBrowserEntry) {
+		for folderPath := range values {
+			if virtualPathWithinSubtree(targetFolderPath, folderPath) {
+				folders[folderPath] = struct{}{}
+			}
+		}
+	}
+	collectTracks := func(values map[string][]LibraryIndexedFile) {
+		for folderPath := range values {
+			if virtualPathWithinSubtree(targetFolderPath, folderPath) {
+				folders[folderPath] = struct{}{}
+			}
+		}
+	}
+	collectEntries(indexData.folderEntriesByFolder)
+	collectTracks(indexData.trackFilesByFolder)
+	collectEntries(indexData.directTextEntriesByFolder)
+	collectEntries(indexData.directImageEntriesByFolder)
+	for folderPath := range indexData.folderChildPathsByFolder {
+		if virtualPathWithinSubtree(targetFolderPath, folderPath) {
+			folders[folderPath] = struct{}{}
+		}
+	}
+	for folderPath := range indexData.folderModifiedAtByPath {
+		if virtualPathWithinSubtree(targetFolderPath, folderPath) {
+			folders[folderPath] = struct{}{}
+		}
+	}
+	return folders
+}
+
+func (a *App) applyIncrementalDerivedIndexUpdatesLocked(updates []incrementalDerivedIndexUpdate) {
+	indexState := a.libraryIndexState()
+	contentState := a.libraryContentState()
+	if !a.isLibraryFolderIndexReadyLocked() {
+		a.markLibrarySearchIndexDirtyLocked()
+		return
+	}
+	affectedCoverFolders := make(map[string]struct{})
+	for _, update := range updates {
+		for folderPath := range update.affectedCoverFolders {
+			affectedCoverFolders[folderPath] = struct{}{}
+		}
+
+		newSubtreeFolders := folderSetFromFolderIndexData(update.subtreeFolderIndex, update.targetFolderPath)
+		for folderPath := range update.previousSubtreeFolders {
+			if _, exists := newSubtreeFolders[folderPath]; exists {
+				continue
+			}
+			delete(indexState.folderEntriesByFolder, folderPath)
+			delete(indexState.folderChildPathsByFolder, folderPath)
+			delete(indexState.trackFilesByFolder, folderPath)
+			delete(indexState.directTextEntriesByFolder, folderPath)
+			delete(indexState.directImageEntriesByFolder, folderPath)
+			delete(indexState.folderModifiedAtByPath, folderPath)
+		}
+
+		for folderPath := range newSubtreeFolders {
+			indexState.folderChildPathsByFolder[folderPath] = append([]string(nil), update.subtreeFolderIndex.folderChildPathsByFolder[folderPath]...)
+			indexState.trackFilesByFolder[folderPath] = cloneIndexedFiles(update.subtreeFolderIndex.trackFilesByFolder[folderPath])
+			indexState.directTextEntriesByFolder[folderPath] = cloneBrowserEntries(update.subtreeFolderIndex.directTextEntriesByFolder[folderPath])
+			indexState.directImageEntriesByFolder[folderPath] = cloneBrowserEntries(update.subtreeFolderIndex.directImageEntriesByFolder[folderPath])
+			indexState.folderModifiedAtByPath[folderPath] = update.subtreeFolderIndex.folderModifiedAtByPath[folderPath]
+			indexState.folderEntriesByFolder[folderPath] = cloneBrowserEntries(update.subtreeFolderIndex.folderEntriesByFolder[folderPath])
+		}
+
+		ancestors := ancestorFolderPathsBottomUp(update.targetFolderPath)
+		for index, folderPath := range ancestors {
+			if index > 0 {
+				parentPath := ancestors[index]
+				childPath := ancestors[index-1]
+				childPaths := indexState.folderChildPathsByFolder[parentPath]
+				if a.folderExistsInDerivedIndexLocked(childPath) {
+					indexState.folderChildPathsByFolder[parentPath] = appendSortedUniqueChildPath(childPaths, childPath)
+				} else {
+					indexState.folderChildPathsByFolder[parentPath] = removeChildPath(childPaths, childPath)
+				}
+			}
+
+			folderExists := a.folderExistsInDerivedIndexLocked(folderPath)
+			if !folderExists && folderPath != "" {
+				delete(indexState.folderEntriesByFolder, folderPath)
+				delete(indexState.folderChildPathsByFolder, folderPath)
+				delete(indexState.trackFilesByFolder, folderPath)
+				delete(indexState.directTextEntriesByFolder, folderPath)
+				delete(indexState.directImageEntriesByFolder, folderPath)
+				delete(indexState.folderModifiedAtByPath, folderPath)
+				continue
+			}
+
+			indexState.folderModifiedAtByPath[folderPath] = a.recomputeFolderModifiedAtFromDerivedIndexLocked(folderPath)
+			indexState.folderEntriesByFolder[folderPath] = a.buildFolderEntriesFromDerivedCachesLocked(folderPath)
+		}
+	}
+
+	if contentState.libraryScan.CoverPathByFolder == nil {
+		contentState.libraryScan.CoverPathByFolder = make(map[string]string)
+	}
+	for folderPath := range affectedCoverFolders {
+		folderKey := strings.ToLower(folderPath)
+		coverPath := a.bestCoverPathForFolderFromContentLocked(folderPath)
+		if coverPath == "" {
+			delete(contentState.libraryScan.CoverPathByFolder, folderKey)
+		} else {
+			contentState.libraryScan.CoverPathByFolder[folderKey] = coverPath
+		}
+	}
+
+	a.markLibrarySearchIndexDirtyLocked()
 }
 
 func addFolderAncestorsToIndex(folderPath string, folderChildSetByParent map[string]map[string]struct{}, folderPaths map[string]struct{}) {
@@ -216,7 +553,7 @@ func noteFolderModifiedAt(folderModifiedAtByPath map[string]int64, folderPath st
 	}
 }
 
-func buildLibraryDerivedIndexData(trackFiles []LibraryIndexedFile, textFiles []LibraryIndexedFile, imageFiles []LibraryIndexedFile) libraryDerivedIndexData {
+func buildLibraryFolderIndexData(trackFiles []LibraryIndexedFile, textFiles []LibraryIndexedFile, imageFiles []LibraryIndexedFile) libraryFolderIndexData {
 	folderChildSetByParent := make(map[string]map[string]struct{})
 	folderPaths := map[string]struct{}{}
 	folderModifiedAtByPath := make(map[string]int64)
@@ -226,17 +563,12 @@ func buildLibraryDerivedIndexData(trackFiles []LibraryIndexedFile, textFiles []L
 	imageEntriesByFolder := make(map[string][]LibraryBrowserEntry)
 	trackFilesByFolder := make(map[string][]LibraryIndexedFile)
 
-	searchTrackEntries := make([]LibraryBrowserEntry, 0, len(trackFiles))
-	searchTextEntries := make([]LibraryBrowserEntry, 0, len(textFiles))
-	searchImageEntries := make([]LibraryBrowserEntry, 0, len(imageFiles))
-
 	for _, indexed := range trackFiles {
 		addFolderAncestorsToIndex(indexed.FolderPath, folderChildSetByParent, folderPaths)
 		noteFolderModifiedAt(folderModifiedAtByPath, indexed.FolderPath, indexed.ModifiedAtMs)
 		entry := browserEntryFromIndexedFile("track", indexed)
 		trackEntriesByFolder[indexed.FolderPath] = append(trackEntriesByFolder[indexed.FolderPath], entry)
 		trackFilesByFolder[indexed.FolderPath] = append(trackFilesByFolder[indexed.FolderPath], indexed)
-		searchTrackEntries = append(searchTrackEntries, entry)
 	}
 
 	for _, indexed := range textFiles {
@@ -244,7 +576,6 @@ func buildLibraryDerivedIndexData(trackFiles []LibraryIndexedFile, textFiles []L
 		noteFolderModifiedAt(folderModifiedAtByPath, indexed.FolderPath, indexed.ModifiedAtMs)
 		entry := browserEntryFromIndexedFile("text-file", indexed)
 		textEntriesByFolder[indexed.FolderPath] = append(textEntriesByFolder[indexed.FolderPath], entry)
-		searchTextEntries = append(searchTextEntries, entry)
 	}
 
 	for _, indexed := range imageFiles {
@@ -252,7 +583,6 @@ func buildLibraryDerivedIndexData(trackFiles []LibraryIndexedFile, textFiles []L
 		noteFolderModifiedAt(folderModifiedAtByPath, indexed.FolderPath, indexed.ModifiedAtMs)
 		entry := browserEntryFromIndexedFile("image-file", indexed)
 		imageEntriesByFolder[indexed.FolderPath] = append(imageEntriesByFolder[indexed.FolderPath], entry)
-		searchImageEntries = append(searchImageEntries, entry)
 	}
 
 	folderKeys := map[string]struct{}{"": {}}
@@ -275,6 +605,8 @@ func buildLibraryDerivedIndexData(trackFiles []LibraryIndexedFile, textFiles []L
 	folderEntriesByFolder := make(map[string][]LibraryBrowserEntry, len(folderKeys))
 	folderChildPathsByFolder := make(map[string][]string, len(folderKeys))
 	sortedTrackFilesByFolder := make(map[string][]LibraryIndexedFile, len(folderKeys))
+	sortedTextEntriesByFolder := make(map[string][]LibraryBrowserEntry, len(folderKeys))
+	sortedImageEntriesByFolder := make(map[string][]LibraryBrowserEntry, len(folderKeys))
 
 	for folderPath := range folderKeys {
 		childPaths := make([]string, 0)
@@ -298,6 +630,8 @@ func buildLibraryDerivedIndexData(trackFiles []LibraryIndexedFile, textFiles []L
 		sortBrowserEntriesByName(directTrackEntries)
 		sortBrowserEntriesByName(directTextEntries)
 		sortBrowserEntriesByName(directImageEntries)
+		sortedTextEntriesByFolder[folderPath] = directTextEntries
+		sortedImageEntriesByFolder[folderPath] = directImageEntries
 
 		entries := make([]LibraryBrowserEntry, 0, len(childEntries)+len(directTrackEntries)+len(directTextEntries)+len(directImageEntries))
 		entries = append(entries, childEntries...)
@@ -323,18 +657,48 @@ func buildLibraryDerivedIndexData(trackFiles []LibraryIndexedFile, textFiles []L
 	}
 
 	sortBrowserEntriesByPath(searchFolderEntries)
+
+	return libraryFolderIndexData{
+		folderEntriesByFolder:      folderEntriesByFolder,
+		folderChildPathsByFolder:   folderChildPathsByFolder,
+		trackFilesByFolder:         sortedTrackFilesByFolder,
+		directTextEntriesByFolder:  sortedTextEntriesByFolder,
+		directImageEntriesByFolder: sortedImageEntriesByFolder,
+		folderModifiedAtByPath:     folderModifiedAtByPath,
+		searchFolderEntries:        searchFolderEntries,
+	}
+}
+
+func buildLibrarySearchIndexData(trackFiles []LibraryIndexedFile, textFiles []LibraryIndexedFile, imageFiles []LibraryIndexedFile) librarySearchIndexData {
+	searchTrackEntries := make([]LibraryBrowserEntry, 0, len(trackFiles))
+	searchTextEntries := make([]LibraryBrowserEntry, 0, len(textFiles))
+	searchImageEntries := make([]LibraryBrowserEntry, 0, len(imageFiles))
+
+	for _, indexed := range trackFiles {
+		searchTrackEntries = append(searchTrackEntries, browserEntryFromIndexedFile("track", indexed))
+	}
+	for _, indexed := range textFiles {
+		searchTextEntries = append(searchTextEntries, browserEntryFromIndexedFile("text-file", indexed))
+	}
+	for _, indexed := range imageFiles {
+		searchImageEntries = append(searchImageEntries, browserEntryFromIndexedFile("image-file", indexed))
+	}
+
 	sortBrowserEntriesByRelativePath(searchTrackEntries)
 	sortBrowserEntriesByRelativePath(searchTextEntries)
 	sortBrowserEntriesByRelativePath(searchImageEntries)
 
+	return librarySearchIndexData{
+		searchTrackEntries: searchTrackEntries,
+		searchTextEntries:  searchTextEntries,
+		searchImageEntries: searchImageEntries,
+	}
+}
+
+func buildLibraryDerivedIndexData(trackFiles []LibraryIndexedFile, textFiles []LibraryIndexedFile, imageFiles []LibraryIndexedFile) libraryDerivedIndexData {
 	return libraryDerivedIndexData{
-		folderEntriesByFolder:    folderEntriesByFolder,
-		folderChildPathsByFolder: folderChildPathsByFolder,
-		trackFilesByFolder:       sortedTrackFilesByFolder,
-		searchFolderEntries:      searchFolderEntries,
-		searchTrackEntries:       searchTrackEntries,
-		searchTextEntries:        searchTextEntries,
-		searchImageEntries:       searchImageEntries,
+		libraryFolderIndexData: buildLibraryFolderIndexData(trackFiles, textFiles, imageFiles),
+		librarySearchIndexData: buildLibrarySearchIndexData(trackFiles, textFiles, imageFiles),
 	}
 }
 

--- a/app_library_queries.go
+++ b/app_library_queries.go
@@ -114,14 +114,9 @@ func (a *App) resolveAvailableLibraryFolderForVirtualPathLocked(virtualFolderPat
 		return ""
 	}
 	contentState := a.libraryContentState()
-	scanState := a.libraryScanState()
 	indexState := a.libraryIndexState()
 
-	if !scanState.scanInProgress {
-		a.maybeStartLibraryDerivedIndexRebuildLocked()
-	}
-
-	if a.isLibraryDerivedIndexReadyLocked() {
+	if a.isLibraryFolderIndexReadyLocked() {
 		if _, exists := indexState.folderEntriesByFolder[normalizedFolderPath]; exists {
 			return normalizedFolderPath
 		}
@@ -304,11 +299,7 @@ func (a *App) GetLibraryFolderPageSorted(folderPath string, sortMode string, off
 	useFilesystemFallback := false
 	var rootsSnapshot []libraryRootConfig
 	activeGeneration := generationState.libraryScanGeneration.Load()
-	if !scanState.scanInProgress {
-		a.maybeStartLibraryDerivedIndexRebuildLocked()
-	}
-
-	if a.isLibraryDerivedIndexReadyLocked() {
+	if a.isLibraryFolderIndexReadyLocked() {
 		entries = indexState.folderEntriesByFolder[normalizedFolderPath]
 		mode = "derived-index"
 	} else if scanState.scanInProgress {
@@ -376,7 +367,6 @@ func (a *App) SearchLibrary(query string, offset int, limit int) LibrarySearchPa
 	logQuery := searchQueryForLog(query)
 	generationState := a.libraryGenerationState()
 	contentState := a.libraryContentState()
-	scanState := a.libraryScanState()
 	indexState := a.libraryIndexState()
 	searchGeneration := generationState.searchGeneration.Load()
 	if offset <= 0 {
@@ -429,14 +419,11 @@ func (a *App) SearchLibrary(query string, offset int, limit int) LibrarySearchPa
 	var entries []LibraryBrowserEntry
 	mode := "fallback-map"
 	canceled := false
-	if !scanState.scanInProgress {
-		a.maybeStartLibraryDerivedIndexRebuildLocked()
-	}
 
 	if hasMusicBrainzTagQuery {
 		entries = a.buildMusicBrainzTagSearchResultsLocked(musicBrainzTagQuery)
 		mode = "musicbrainz-tags"
-	} else if a.isLibraryDerivedIndexReadyLocked() {
+	} else if a.isLibrarySearchIndexReadyLocked() {
 		var derivedMode string
 		entries, derivedMode, canceled = a.buildSearchResultsLocked(normalizedQuery, searchCanceled)
 		mode = "derived-" + derivedMode
@@ -546,18 +533,13 @@ func (a *App) GetLibraryFolderTrackPaths(folderPath string) []string {
 		return []string{}
 	}
 	contentState := a.libraryContentState()
-	scanState := a.libraryScanState()
 
 	contentState.indexMu.Lock()
 
 	mode := "fallback-map"
 	useFilesystemFallback := false
 	var rootsSnapshot []libraryRootConfig
-	if !scanState.scanInProgress {
-		a.maybeStartLibraryDerivedIndexRebuildLocked()
-	}
-
-	if a.isLibraryDerivedIndexReadyLocked() {
+	if a.isLibraryFolderIndexReadyLocked() {
 		mode = "derived-index"
 		paths := a.getFolderTrackPathsFromDerivedIndexLocked(normalizedFolderPath)
 		contentState.indexMu.Unlock()
@@ -611,18 +593,13 @@ func (a *App) GetLibraryFolderTrackCount(folderPath string) int {
 		return 0
 	}
 	contentState := a.libraryContentState()
-	scanState := a.libraryScanState()
 
 	contentState.indexMu.Lock()
 
 	mode := "fallback-map"
 	useFilesystemFallback := false
 	var rootsSnapshot []libraryRootConfig
-	if !scanState.scanInProgress {
-		a.maybeStartLibraryDerivedIndexRebuildLocked()
-	}
-
-	if a.isLibraryDerivedIndexReadyLocked() {
+	if a.isLibraryFolderIndexReadyLocked() {
 		mode = "derived-index"
 		count := a.getFolderTrackCountFromDerivedIndexLocked(normalizedFolderPath)
 		contentState.indexMu.Unlock()

--- a/app_library_queries_additional_test.go
+++ b/app_library_queries_additional_test.go
@@ -583,10 +583,7 @@ func TestSearchLibraryCancellationAfterBuild(t *testing.T) {
 
 		select {
 		case scheduledCancellation <- struct{}{}:
-			go func() {
-				time.Sleep(time.Millisecond)
-				app.searchGeneration.Add(1)
-			}()
+			app.searchGeneration.Add(1)
 		default:
 		}
 	}

--- a/app_library_scan.go
+++ b/app_library_scan.go
@@ -155,7 +155,6 @@ func (a *App) scanLibraryFolders(folders []AppLibraryFolder, restartWatcher bool
 		scanState.scanInProgress = false
 		scanState.scanRemainingImmediateChildrenByFolder = nil
 		scanState.scanDiscoveredChildFoldersByParent = nil
-		a.maybeStartLibraryDerivedIndexRebuildLocked()
 		contentState.indexMu.Unlock()
 	}()
 
@@ -686,6 +685,9 @@ func (a *App) setLibraryIndexFromScan(scan LibraryScanResult, expectedScanGenera
 		len(scan.TrackFiles), len(scan.TextFiles), len(scan.ImageFiles))
 	contentState := a.libraryContentState()
 	generationState := a.libraryGenerationState()
+	folderIndexBuildStartTime := time.Now()
+	folderIndexData := buildLibraryFolderIndexData(scan.TrackFiles, scan.TextFiles, scan.ImageFiles)
+	a.logRescanEvent("  - folder index built (%.2fms)", time.Since(folderIndexBuildStartTime).Seconds()*1000)
 
 	lockWaitStart := time.Now()
 	contentState.indexMu.Lock()
@@ -719,7 +721,15 @@ func (a *App) setLibraryIndexFromScan(scan LibraryScanResult, expectedScanGenera
 	copyCoverStartTime := time.Now()
 	contentState.libraryScan = scan
 	contentState.libraryScan.CoverPathByFolder = cloneCoverPathByFolder(scan.CoverPathByFolder)
-	a.markLibraryDerivedIndexDirtyLocked()
+	indexState := a.libraryIndexState()
+	indexState.folderEntriesByFolder = folderIndexData.folderEntriesByFolder
+	indexState.folderChildPathsByFolder = folderIndexData.folderChildPathsByFolder
+	indexState.trackFilesByFolder = folderIndexData.trackFilesByFolder
+	indexState.directTextEntriesByFolder = folderIndexData.directTextEntriesByFolder
+	indexState.directImageEntriesByFolder = folderIndexData.directImageEntriesByFolder
+	indexState.folderModifiedAtByPath = folderIndexData.folderModifiedAtByPath
+	indexState.searchFolderEntries = folderIndexData.searchFolderEntries
+	a.markLibrarySearchIndexDirtyLocked()
 	a.logRescanEvent("  - cover paths copied (%.2fms)", time.Since(copyCoverStartTime).Seconds()*1000)
 	a.logRescanEvent("setLibraryIndexFromScan END: total time %.2fms", time.Since(setStartTime).Seconds()*1000)
 	return true

--- a/app_library_scan_deferred.go
+++ b/app_library_scan_deferred.go
@@ -689,7 +689,6 @@ func (a *App) startLibraryFileHydrationAsync(roots []libraryRootConfig, expected
 		if generationState.libraryScanGeneration.Load() == expectedScanGeneration {
 			indexState.libraryFileHydrationPending = false
 			indexState.libraryFolderEntriesCache = nil
-			a.maybeStartLibraryDerivedIndexRebuildLocked()
 			shouldEmitUpdate = true
 			payload = compactLibraryScanResult(contentState.libraryScan)
 		}

--- a/app_library_watcher.go
+++ b/app_library_watcher.go
@@ -325,19 +325,6 @@ func addLibraryWatchesRecursive(watcher *fsnotify.Watcher, rootPath string, onPr
 	})
 }
 
-func addLibraryWatchesFromDiscoveredDirectories(watcher *fsnotify.Watcher, directoryPaths []string, onProgress func()) {
-	for _, directoryPath := range directoryPaths {
-		if strings.TrimSpace(directoryPath) == "" {
-			continue
-		}
-
-		_ = watcher.Add(directoryPath)
-		if onProgress != nil {
-			onProgress()
-		}
-	}
-}
-
 func collectWatchableLibraryRootPaths(roots []libraryRootConfig) []string {
 	rootPaths := make([]string, 0, len(roots))
 	for _, root := range roots {
@@ -357,6 +344,10 @@ func collectWatchableLibraryRootPaths(roots []libraryRootConfig) []string {
 
 func collectWatchableLibraryDirectoryPaths(roots []libraryRootConfig, directoryPaths []string) []string {
 	rootPaths := collectWatchableLibraryRootPaths(roots)
+	if libraryWatcherUsesRecursiveRootHandles() {
+		return rootPaths
+	}
+
 	if len(directoryPaths) == 0 {
 		return rootPaths
 	}
@@ -441,7 +432,7 @@ func (a *App) startLibraryWatcherReserved(roots []libraryRootConfig, directoryPa
 
 	a.logRescanEvent("Starting library watcher for %d directories", len(watchablePaths))
 
-	watcher, watcherErr := fsnotify.NewWatcher()
+	watcher, watcherErr := newLibraryEventWatcher(roots, watchablePaths, directoryPaths, onProgress)
 	if watcherErr != nil {
 		a.logRescanEvent("Failed to create filesystem watcher: %v", watcherErr)
 		return false
@@ -450,20 +441,6 @@ func (a *App) startLibraryWatcherReserved(roots []libraryRootConfig, directoryPa
 	if generation > 0 && watcherState.generation.Load() != generation {
 		_ = watcher.Close()
 		return false
-	}
-
-	a.logRescanEvent("Watcher created, registering all directories")
-	if len(directoryPaths) > 0 {
-		addLibraryWatchesFromDiscoveredDirectories(watcher, watchablePaths, onProgress)
-	} else {
-		for _, rootPath := range watchablePaths {
-			if generation > 0 && watcherState.generation.Load() != generation {
-				_ = watcher.Close()
-				return false
-			}
-
-			addLibraryWatchesRecursive(watcher, rootPath, onProgress)
-		}
 	}
 
 	if generation > 0 && watcherState.generation.Load() != generation {
@@ -494,7 +471,7 @@ func (a *App) startLibraryWatcherReserved(roots []libraryRootConfig, directoryPa
 		_ = previousWatcher.Close()
 	}
 
-	go func(activeWatcher *fsnotify.Watcher, activeStopCh chan struct{}) {
+	go func(activeWatcher libraryEventWatcher, activeStopCh chan struct{}) {
 		runtimeState := a.runtimeState()
 		defer func() {
 			_ = activeWatcher.Close()
@@ -531,7 +508,7 @@ func (a *App) startLibraryWatcherReserved(roots []libraryRootConfig, directoryPa
 				}
 				return
 
-			case event, ok := <-activeWatcher.Events:
+			case event, ok := <-activeWatcher.Events():
 				if !ok {
 					if timer != nil {
 						timer.Stop()
@@ -540,9 +517,7 @@ func (a *App) startLibraryWatcherReserved(roots []libraryRootConfig, directoryPa
 				}
 
 				if event.Op&fsnotify.Create != 0 {
-					if info, statErr := os.Stat(event.Name); statErr == nil && info.IsDir() {
-						addLibraryWatchesRecursive(activeWatcher, event.Name, nil)
-					}
+					activeWatcher.HandleCreatePath(event.Name)
 				}
 
 				if isRelevantWatchEvent(event) {
@@ -567,13 +542,14 @@ func (a *App) startLibraryWatcherReserved(roots []libraryRootConfig, directoryPa
 					a.logRescanEvent("EventsEmit END: took %.2fms", time.Since(emitStartTime).Seconds()*1000)
 				}
 
-			case _, ok := <-activeWatcher.Errors:
+			case watcherErr, ok := <-activeWatcher.Errors():
 				if !ok {
 					if timer != nil {
 						timer.Stop()
 					}
 					return
 				}
+				a.logRescanEvent("Library watcher error: %v", watcherErr)
 			}
 		}
 	}(watcher, stopCh)

--- a/app_library_watcher.go
+++ b/app_library_watcher.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 var beforeIncrementalLibraryPathScanHook func(string)
 
 type preparedIncrementalLibraryChange struct {
+	root       libraryRootConfig
 	targetPath string
 	trackFiles []LibraryIndexedFile
 	textFiles  []LibraryIndexedFile
@@ -73,7 +75,7 @@ func (a *App) prepareIncrementalLibraryChange(root libraryRootConfig, targetPath
 	}
 
 	startTime := time.Now()
-	prepared := preparedIncrementalLibraryChange{targetPath: targetPath}
+	prepared := preparedIncrementalLibraryChange{root: root, targetPath: targetPath}
 	info, err := os.Stat(targetPath)
 	if err != nil {
 		return prepared
@@ -196,10 +198,78 @@ func (a *App) addOrUpdatePathRecursive(root libraryRootConfig, targetPath string
 	a.applyPreparedIncrementalLibraryChange(prepared)
 }
 
+func incrementalLibraryChangeTargetPath(changedPath string) string {
+	absolutePath, ok := absoluteNormalizedPath(changedPath)
+	if !ok {
+		return ""
+	}
+
+	info, err := os.Stat(absolutePath)
+	if err == nil && info.IsDir() {
+		return absolutePath
+	}
+
+	if isImagePath(absolutePath) {
+		return filepath.Dir(absolutePath)
+	}
+
+	return absolutePath
+}
+
+func coalesceIncrementalLibraryChangePaths(changedPaths []string) []string {
+	normalizedPaths := make([]string, 0, len(changedPaths))
+	seen := make(map[string]struct{}, len(changedPaths))
+	for _, changedPath := range changedPaths {
+		targetPath := incrementalLibraryChangeTargetPath(changedPath)
+		if targetPath == "" {
+			continue
+		}
+
+		if _, exists := seen[targetPath]; exists {
+			continue
+		}
+
+		seen[targetPath] = struct{}{}
+		normalizedPaths = append(normalizedPaths, targetPath)
+	}
+
+	if len(normalizedPaths) <= 1 {
+		return normalizedPaths
+	}
+
+	sort.Slice(normalizedPaths, func(i int, j int) bool {
+		left := normalizedPaths[i]
+		right := normalizedPaths[j]
+		if len(left) == len(right) {
+			return left < right
+		}
+		return len(left) < len(right)
+	})
+
+	coalesced := make([]string, 0, len(normalizedPaths))
+	for _, candidate := range normalizedPaths {
+		covered := false
+		for _, existing := range coalesced {
+			if pathWithinRoot(existing, candidate) {
+				covered = true
+				break
+			}
+		}
+		if covered {
+			continue
+		}
+
+		coalesced = append(coalesced, candidate)
+	}
+
+	return coalesced
+}
+
 // applyIncrementalLibraryChanges resolves the owning root for each changed path
 // so one debounced watcher batch can update multiple configured library folders.
 func (a *App) applyIncrementalLibraryChanges(changedPaths []string) (LibraryScanResult, bool) {
 	startTime := time.Now()
+	changedPaths = coalesceIncrementalLibraryChangePaths(changedPaths)
 	a.logRescanEvent("applyIncrementalLibraryChanges START with %d paths", len(changedPaths))
 	contentState := a.libraryContentState()
 	scanState := a.libraryScanState()
@@ -255,7 +325,6 @@ func (a *App) applyIncrementalLibraryChanges(changedPaths []string) (LibraryScan
 	}
 
 	contentState.indexMu.Lock()
-	defer contentState.indexMu.Unlock()
 	if generationState.libraryScanGeneration.Load() != expectedGeneration || indexState.libraryFileHydrationPending || scanState.scanInProgress {
 		a.logRescanEvent(
 			"applyIncrementalLibraryChanges skipped before commit: generation=%d active=%d hydrationPending=%t scanInProgress=%t",
@@ -264,10 +333,25 @@ func (a *App) applyIncrementalLibraryChanges(changedPaths []string) (LibraryScan
 			indexState.libraryFileHydrationPending,
 			scanState.scanInProgress,
 		)
+		contentState.indexMu.Unlock()
 		return LibraryScanResult{}, false
 	}
+
+	indexUpdates := make([]incrementalDerivedIndexUpdate, 0, len(preparedChanges))
+	hasIndexedChanges := false
 	for _, prepared := range preparedChanges {
+		if len(prepared.trackFiles) == 0 && len(prepared.textFiles) == 0 && len(prepared.imageFiles) == 0 && !a.pathHasIndexedContentLocked(prepared.targetPath) {
+			continue
+		}
+
+		indexUpdates = append(indexUpdates, a.collectIncrementalDerivedIndexUpdateLocked(prepared))
 		a.applyPreparedIncrementalLibraryChange(prepared)
+		hasIndexedChanges = true
+	}
+
+	if !hasIndexedChanges {
+		contentState.indexMu.Unlock()
+		return LibraryScanResult{}, false
 	}
 
 	// Avoid expensive full snapshot rebuild for incremental changes.
@@ -275,14 +359,11 @@ func (a *App) applyIncrementalLibraryChanges(changedPaths []string) (LibraryScan
 	// The file arrays are still valid (items may have been added/removed from the maps,
 	// but the snapshot lists are consistent for the event emission).
 	updateStartTime := time.Now()
+	a.applyIncrementalDerivedIndexUpdatesLocked(indexUpdates)
 	contentState.libraryScan.TrackCount = len(contentState.trackByPath)
 	contentState.libraryScan.TextFileCount = len(contentState.textByPath)
 	contentState.libraryScan.ImageFileCount = len(contentState.imageByPath)
 	contentState.libraryScan.TotalEntries = contentState.libraryScan.TrackCount + contentState.libraryScan.TextFileCount + contentState.libraryScan.ImageFileCount
-	a.markLibraryDerivedIndexDirtyLocked()
-	a.maybeStartLibraryDerivedIndexRebuildLocked()
-	a.notifyMusicBrainzTagWorker()
-	a.notifyLibraryFilesDatabaseWorker()
 
 	// Emit only the lightweight metadata — the frontend no longer uses the file arrays
 	// for incremental updates, and serializing 150K+ entries over IPC takes several seconds.
@@ -296,6 +377,9 @@ func (a *App) applyIncrementalLibraryChanges(changedPaths []string) (LibraryScan
 		Truncated:      contentState.libraryScan.Truncated,
 		EntryLimit:     contentState.libraryScan.EntryLimit,
 	}
+	contentState.indexMu.Unlock()
+	a.notifyMusicBrainzTagWorker()
+	a.notifyLibraryFilesDatabaseWorkerIncremental(preparedChanges, notification.TotalEntries)
 	a.logRescanEvent("applyIncrementalLibraryChanges update took %.2fms, total time %.2fms",
 		time.Since(updateStartTime).Seconds()*1000, time.Since(startTime).Seconds()*1000)
 
@@ -477,7 +561,10 @@ func (a *App) startLibraryWatcherReserved(roots []libraryRootConfig, directoryPa
 			_ = activeWatcher.Close()
 		}()
 
-		const debounceDuration = 500 * time.Millisecond
+		debounceDuration := activeWatcher.DebounceDuration()
+		if debounceDuration <= 0 {
+			debounceDuration = 500 * time.Millisecond
+		}
 		var timer *time.Timer
 		var timerC <-chan time.Time
 		pendingPaths := make(map[string]struct{})

--- a/app_library_watcher_additional_test.go
+++ b/app_library_watcher_additional_test.go
@@ -5,11 +5,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
+
+const libraryWatcherUpdateTimeout = 6 * time.Second
 
 func waitForLibraryWatcherToStart(t *testing.T, app *App) {
 	t.Helper()
@@ -247,7 +251,7 @@ func TestLibraryWatcherHelpersAndRuntimeEvents(t *testing.T) {
 	newTrack := filepath.Join(fixture.albumOneFolder, "99 Watched.flac")
 	writeTestFile(t, newTrack, "watched")
 
-	watchDeadline := time.Now().Add(2 * time.Second)
+	watchDeadline := time.Now().Add(libraryWatcherUpdateTimeout)
 	for time.Now().Before(watchDeadline) {
 		app.indexMu.Lock()
 		_, exists := app.trackByPath[normalizePath(newTrack)]
@@ -273,6 +277,110 @@ func TestLibraryWatcherHelpersAndRuntimeEvents(t *testing.T) {
 	app.startLibraryWatcher(nil, nil)
 	if watcherState.watcher != nil {
 		t.Fatal("startLibraryWatcher(nil) should leave watcher nil")
+	}
+}
+
+func TestIncrementalLibraryChangesAmendDerivedFolderIndexInPlace(t *testing.T) {
+	originalRuntimeEventsEmit := runtimeEventsEmit
+	var logMu sync.Mutex
+	logLines := make([]string, 0, 32)
+	runtimeEventsEmit = func(_ context.Context, eventName string, optionalData ...interface{}) {
+		if eventName != libraryRescanLogEvent || len(optionalData) == 0 {
+			return
+		}
+		line, ok := optionalData[0].(string)
+		if !ok {
+			return
+		}
+		logMu.Lock()
+		logLines = append(logLines, line)
+		logMu.Unlock()
+	}
+	t.Cleanup(func() {
+		runtimeEventsEmit = originalRuntimeEventsEmit
+	})
+
+	fixture := createLibraryTestFixture(t)
+	app := NewApp()
+	app.ctx = context.Background()
+
+	scanResult := app.scanLibraryFolder(fixture.rootOne, false)
+	if scanResult.ImageFileCount != 2 {
+		t.Fatalf("scanLibraryFolder() = %#v, want both fixture images indexed", scanResult)
+	}
+
+	albumFolderPath := ""
+	app.indexMu.Lock()
+	indexedCover, exists := app.imageByPath[normalizePath(fixture.coverOne)]
+	if exists {
+		albumFolderPath = indexedCover.FolderPath
+	}
+	app.indexMu.Unlock()
+	if !exists {
+		t.Fatalf("initial image index is missing %q", fixture.coverOne)
+	}
+	if got := app.GetLibraryFolderCoverPath(albumFolderPath); got != fixture.coverOne {
+		t.Fatalf("GetLibraryFolderCoverPath(before incremental update) = %q, want %q", got, fixture.coverOne)
+	}
+
+	logMu.Lock()
+	logLines = nil
+	logMu.Unlock()
+
+	if err := os.Remove(fixture.coverOne); err != nil {
+		t.Fatalf("Remove(%q) error = %v", fixture.coverOne, err)
+	}
+
+	notification, changed := app.applyIncrementalLibraryChanges([]string{fixture.coverOne})
+	if !changed {
+		t.Fatal("applyIncrementalLibraryChanges(removed cover) = false, want true")
+	}
+	if notification.ImageFileCount != 1 {
+		t.Fatalf("applyIncrementalLibraryChanges(removed cover) = %#v, want one indexed image remaining", notification)
+	}
+
+	app.indexMu.Lock()
+	folderIndexReady := app.isLibraryFolderIndexReadyLocked()
+	derivedDirty := app.libraryDerivedIndexDirty
+	derivedBuilding := app.libraryDerivedIndexBuilding
+	searchTrackEntriesReady := app.searchTrackEntries != nil
+	app.indexMu.Unlock()
+	if !folderIndexReady {
+		t.Fatal("incremental cover-art update should keep the folder-derived index ready")
+	}
+	if !derivedDirty || derivedBuilding {
+		t.Fatalf("incremental cover-art update should leave only the search corpus dirty/building = %t/%t, want true/false", derivedDirty, derivedBuilding)
+	}
+	if searchTrackEntriesReady {
+		t.Fatal("incremental cover-art update should invalidate the global search corpus instead of rebuilding it eagerly")
+	}
+
+	if got := app.GetLibraryFolderCoverPath(albumFolderPath); got != fixture.folderCoverOne {
+		t.Fatalf("GetLibraryFolderCoverPath(after incremental update) = %q, want %q", got, fixture.folderCoverOne)
+	}
+
+	page := app.GetLibraryFolderPage(albumFolderPath, 0, 10)
+	if page.TotalEntries != 3 {
+		t.Fatalf("GetLibraryFolderPage(after incremental update) = %#v, want 3 remaining entries", page)
+	}
+	for _, entry := range page.Entries {
+		if entry.Path == normalizePath(fixture.coverOne) {
+			t.Fatalf("GetLibraryFolderPage(after incremental update) still contains removed cover entry %#v", entry)
+		}
+	}
+
+	searchPage := app.SearchLibrary("folder.jpg", 0, 10)
+	if searchPage.TotalEntries != 1 || len(searchPage.Entries) != 1 || searchPage.Entries[0].Path != normalizePath(fixture.folderCoverOne) {
+		t.Fatalf("SearchLibrary(folder.jpg) = %#v, want fallback-map results for the remaining cover art", searchPage)
+	}
+
+	logMu.Lock()
+	deferredLogs := append([]string(nil), logLines...)
+	logMu.Unlock()
+	for _, line := range deferredLogs {
+		if strings.Contains(line, "rebuildLibraryDerivedIndex START") {
+			t.Fatalf("incremental cover-art update should not trigger a full derived-index rebuild, but log contained %q", line)
+		}
 	}
 }
 
@@ -351,7 +459,7 @@ func TestLibraryWatcherAdditionalEdgeBranches(t *testing.T) {
 	watchTrack := filepath.Join(watchRoot, "01 Watched.flac")
 	writeTestFile(t, watchTrack, "watched")
 
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(libraryWatcherUpdateTimeout)
 	for time.Now().Before(deadline) {
 		app.indexMu.Lock()
 		_, exists := app.trackByPath[normalizePath(watchTrack)]
@@ -493,5 +601,22 @@ func TestIncrementalLibraryChangesDoNotBlockFolderQueries(t *testing.T) {
 	app.indexMu.Unlock()
 	if !exists {
 		t.Fatalf("applyIncrementalLibraryChanges() did not index %q", newTrack)
+	}
+}
+
+func TestCoalesceIncrementalLibraryChangePaths(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "library")
+	child := filepath.Join(root, "Artist", "Album")
+	grandchild := filepath.Join(child, "01 Track.flac")
+	other := filepath.Join(root, "Other", "Album")
+
+	coalesced := coalesceIncrementalLibraryChangePaths([]string{grandchild, root, child, other, grandchild, "   "})
+	if len(coalesced) != 1 || normalizePath(coalesced[0]) != normalizePath(root) {
+		t.Fatalf("coalesceIncrementalLibraryChangePaths() = %#v, want only root %q", coalesced, root)
+	}
+
+	independent := coalesceIncrementalLibraryChangePaths([]string{child, other})
+	if len(independent) != 2 {
+		t.Fatalf("coalesceIncrementalLibraryChangePaths(independent) = %#v, want two paths", independent)
 	}
 }

--- a/app_library_watcher_additional_test.go
+++ b/app_library_watcher_additional_test.go
@@ -330,7 +330,7 @@ func TestLibraryWatcherAdditionalEdgeBranches(t *testing.T) {
 	if watcherState.watcher == firstWatcher {
 		t.Fatal("startLibraryWatcher(restart) should replace the previous watcher instance")
 	}
-	if err := firstWatcher.Add(fixture.rootOne); err == nil {
+	if !firstWatcher.IsClosed() {
 		t.Fatal("expected the replaced watcher to be closed")
 	}
 

--- a/app_library_watcher_platform_other.go
+++ b/app_library_watcher_platform_other.go
@@ -5,6 +5,7 @@ package main
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
@@ -68,6 +69,10 @@ func (w *fsnotifyLibraryEventWatcher) HandleCreatePath(path string) {
 	if info, statErr := os.Stat(path); statErr == nil && info.IsDir() {
 		addLibraryWatchesRecursive(w.watcher, path, nil)
 	}
+}
+
+func (w *fsnotifyLibraryEventWatcher) DebounceDuration() time.Duration {
+	return 500 * time.Millisecond
 }
 
 func (w *fsnotifyLibraryEventWatcher) IsClosed() bool {

--- a/app_library_watcher_platform_other.go
+++ b/app_library_watcher_platform_other.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type fsnotifyLibraryEventWatcher struct {
+	watcher *fsnotify.Watcher
+	closed  bool
+}
+
+func libraryWatcherUsesRecursiveRootHandles() bool {
+	return false
+}
+
+func newLibraryEventWatcher(roots []libraryRootConfig, watchablePaths []string, directoryPaths []string, onProgress func()) (libraryEventWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(directoryPaths) > 0 {
+		addLibraryWatchesFromDiscoveredDirectories(watcher, watchablePaths, onProgress)
+	} else {
+		for _, rootPath := range watchablePaths {
+			addLibraryWatchesRecursive(watcher, rootPath, onProgress)
+		}
+	}
+
+	return &fsnotifyLibraryEventWatcher{watcher: watcher}, nil
+}
+
+func addLibraryWatchesFromDiscoveredDirectories(watcher *fsnotify.Watcher, directoryPaths []string, onProgress func()) {
+	for _, directoryPath := range directoryPaths {
+		if strings.TrimSpace(directoryPath) == "" {
+			continue
+		}
+
+		_ = watcher.Add(directoryPath)
+		if onProgress != nil {
+			onProgress()
+		}
+	}
+}
+
+func (w *fsnotifyLibraryEventWatcher) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	return w.watcher.Close()
+}
+
+func (w *fsnotifyLibraryEventWatcher) Events() <-chan fsnotify.Event {
+	return w.watcher.Events
+}
+
+func (w *fsnotifyLibraryEventWatcher) Errors() <-chan error {
+	return w.watcher.Errors
+}
+
+func (w *fsnotifyLibraryEventWatcher) HandleCreatePath(path string) {
+	if info, statErr := os.Stat(path); statErr == nil && info.IsDir() {
+		addLibraryWatchesRecursive(w.watcher, path, nil)
+	}
+}
+
+func (w *fsnotifyLibraryEventWatcher) IsClosed() bool {
+	return w.closed
+}

--- a/app_library_watcher_platform_windows.go
+++ b/app_library_watcher_platform_windows.go
@@ -1,0 +1,202 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"golang.org/x/sys/windows"
+)
+
+const windowsLibraryWatchFilter = windows.FILE_NOTIFY_CHANGE_FILE_NAME |
+	windows.FILE_NOTIFY_CHANGE_DIR_NAME |
+	windows.FILE_NOTIFY_CHANGE_LAST_WRITE |
+	windows.FILE_NOTIFY_CHANGE_CREATION |
+	windows.FILE_NOTIFY_CHANGE_SIZE
+
+type windowsLibraryEventWatcher struct {
+	done   chan struct{}
+	events chan fsnotify.Event
+	errors chan error
+
+	mu     sync.Mutex
+	closed bool
+	stop   windows.Handle
+	roots  []*windowsLibraryWatchRoot
+	wg     sync.WaitGroup
+}
+
+type windowsLibraryWatchRoot struct {
+	path   string
+	handle windows.Handle
+	ready  chan error
+}
+
+func libraryWatcherUsesRecursiveRootHandles() bool {
+	return true
+}
+
+func newLibraryEventWatcher(roots []libraryRootConfig, _ []string, _ []string, onProgress func()) (libraryEventWatcher, error) {
+	rootPaths := collectWatchableLibraryRootPaths(roots)
+	if len(rootPaths) == 0 {
+		return nil, fmt.Errorf("no valid library roots to watch")
+	}
+
+	stopSignal, err := windows.CreateEvent(nil, 1, 0, nil)
+	if err != nil {
+		return nil, os.NewSyscallError("CreateEvent", err)
+	}
+
+	watcher := &windowsLibraryEventWatcher{
+		done:   make(chan struct{}),
+		events: make(chan fsnotify.Event, 256),
+		errors: make(chan error, 32),
+		stop:   stopSignal,
+		roots:  make([]*windowsLibraryWatchRoot, 0, len(rootPaths)),
+	}
+
+	for _, rootPath := range rootPaths {
+		handle, handleErr := windows.FindFirstChangeNotification(rootPath, true, windowsLibraryWatchFilter)
+		if handleErr != nil {
+			_ = watcher.Close()
+			return nil, os.NewSyscallError("FindFirstChangeNotification", handleErr)
+		}
+
+		watcher.roots = append(watcher.roots, &windowsLibraryWatchRoot{
+			path:   rootPath,
+			handle: handle,
+			ready:  make(chan error, 1),
+		})
+		if onProgress != nil {
+			onProgress()
+		}
+	}
+
+	for _, root := range watcher.roots {
+		watcher.wg.Add(1)
+		go watcher.watchRoot(root)
+		if err := <-root.ready; err != nil {
+			_ = watcher.Close()
+			return nil, err
+		}
+	}
+
+	return watcher, nil
+}
+
+func (w *windowsLibraryEventWatcher) watchRoot(root *windowsLibraryWatchRoot) {
+	defer w.wg.Done()
+
+	root.ready <- nil
+	for {
+		status, err := windows.WaitForMultipleObjects([]windows.Handle{w.stop, root.handle}, false, windows.INFINITE)
+		if err != nil {
+			if w.isClosed() {
+				return
+			}
+
+			w.sendError(os.NewSyscallError("WaitForMultipleObjects", err))
+			return
+		}
+
+		if status == windows.WAIT_OBJECT_0 {
+			return
+		}
+		if status != windows.WAIT_OBJECT_0+1 {
+			w.sendError(fmt.Errorf("unexpected watcher wait status: %d", status))
+			return
+		}
+
+		if !w.sendEvent(fsnotify.Event{Name: root.path, Op: fsnotify.Write}) {
+			return
+		}
+
+		if err := windows.FindNextChangeNotification(root.handle); err != nil {
+			if w.isClosed() {
+				return
+			}
+
+			w.sendError(os.NewSyscallError("FindNextChangeNotification", err))
+			return
+		}
+	}
+}
+
+func (w *windowsLibraryEventWatcher) Close() error {
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return nil
+	}
+	w.closed = true
+	close(w.done)
+	roots := append([]*windowsLibraryWatchRoot(nil), w.roots...)
+	stop := w.stop
+	w.stop = 0
+	w.mu.Unlock()
+
+	if stop != 0 {
+		_ = windows.SetEvent(stop)
+	}
+	w.wg.Wait()
+
+	for _, root := range roots {
+		if root == nil || root.handle == 0 {
+			continue
+		}
+		_ = windows.FindCloseChangeNotification(root.handle)
+		root.handle = 0
+	}
+	if stop != 0 {
+		_ = windows.CloseHandle(stop)
+	}
+	close(w.events)
+	close(w.errors)
+	return nil
+}
+
+func (w *windowsLibraryEventWatcher) Events() <-chan fsnotify.Event {
+	return w.events
+}
+
+func (w *windowsLibraryEventWatcher) Errors() <-chan error {
+	return w.errors
+}
+
+func (w *windowsLibraryEventWatcher) HandleCreatePath(string) {
+}
+
+func (w *windowsLibraryEventWatcher) IsClosed() bool {
+	return w.isClosed()
+}
+
+func (w *windowsLibraryEventWatcher) isClosed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closed
+}
+
+func (w *windowsLibraryEventWatcher) sendEvent(event fsnotify.Event) bool {
+	select {
+	case <-w.done:
+		return false
+	case w.events <- event:
+		return true
+	}
+}
+
+func (w *windowsLibraryEventWatcher) sendError(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	select {
+	case <-w.done:
+		return false
+	case w.errors <- err:
+		return true
+	}
+}

--- a/app_library_watcher_platform_windows.go
+++ b/app_library_watcher_platform_windows.go
@@ -3,19 +3,27 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
+	"time"
+	"unsafe"
 
 	"github.com/fsnotify/fsnotify"
 	"golang.org/x/sys/windows"
 )
+
+const windowsLibraryWatcherBufferSize = 64 * 1024
 
 const windowsLibraryWatchFilter = windows.FILE_NOTIFY_CHANGE_FILE_NAME |
 	windows.FILE_NOTIFY_CHANGE_DIR_NAME |
 	windows.FILE_NOTIFY_CHANGE_LAST_WRITE |
 	windows.FILE_NOTIFY_CHANGE_CREATION |
 	windows.FILE_NOTIFY_CHANGE_SIZE
+
+const windowsLibraryWatcherDebounceDuration = 750 * time.Millisecond
 
 type windowsLibraryEventWatcher struct {
 	done   chan struct{}
@@ -30,9 +38,12 @@ type windowsLibraryEventWatcher struct {
 }
 
 type windowsLibraryWatchRoot struct {
-	path   string
-	handle windows.Handle
-	ready  chan error
+	path       string
+	handle     windows.Handle
+	signal     windows.Handle
+	overlapped windows.Overlapped
+	buffer     []byte
+	ready      chan error
 }
 
 func libraryWatcherUsesRecursiveRootHandles() bool {
@@ -59,17 +70,36 @@ func newLibraryEventWatcher(roots []libraryRootConfig, _ []string, _ []string, o
 	}
 
 	for _, rootPath := range rootPaths {
-		handle, handleErr := windows.FindFirstChangeNotification(rootPath, true, windowsLibraryWatchFilter)
+		handle, handleErr := windows.CreateFile(
+			windows.StringToUTF16Ptr(rootPath),
+			windows.FILE_LIST_DIRECTORY,
+			windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+			nil,
+			windows.OPEN_EXISTING,
+			windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OVERLAPPED,
+			0,
+		)
 		if handleErr != nil {
 			_ = watcher.Close()
-			return nil, os.NewSyscallError("FindFirstChangeNotification", handleErr)
+			return nil, os.NewSyscallError("CreateFile", handleErr)
 		}
 
-		watcher.roots = append(watcher.roots, &windowsLibraryWatchRoot{
+		signal, signalErr := windows.CreateEvent(nil, 1, 0, nil)
+		if signalErr != nil {
+			_ = windows.CloseHandle(handle)
+			_ = watcher.Close()
+			return nil, os.NewSyscallError("CreateEvent", signalErr)
+		}
+
+		root := &windowsLibraryWatchRoot{
 			path:   rootPath,
 			handle: handle,
+			signal: signal,
+			buffer: make([]byte, windowsLibraryWatcherBufferSize),
 			ready:  make(chan error, 1),
-		})
+		}
+		root.overlapped.HEvent = signal
+		watcher.roots = append(watcher.roots, root)
 		if onProgress != nil {
 			onProgress()
 		}
@@ -87,12 +117,82 @@ func newLibraryEventWatcher(roots []libraryRootConfig, _ []string, _ []string, o
 	return watcher, nil
 }
 
+func (r *windowsLibraryWatchRoot) startRead() error {
+	if err := windows.ResetEvent(r.signal); err != nil {
+		return os.NewSyscallError("ResetEvent", err)
+	}
+	r.overlapped = windows.Overlapped{HEvent: r.signal}
+	err := windows.ReadDirectoryChanges(
+		r.handle,
+		&r.buffer[0],
+		uint32(len(r.buffer)),
+		true,
+		windowsLibraryWatchFilter,
+		nil,
+		&r.overlapped,
+		0,
+	)
+	if err != nil && !errors.Is(err, windows.ERROR_IO_PENDING) {
+		return os.NewSyscallError("ReadDirectoryChanges", err)
+	}
+
+	return nil
+}
+
+func parseWindowsLibraryWatchEvents(rootPath string, buffer []byte) []fsnotify.Event {
+	events := make([]fsnotify.Event, 0, 8)
+	offset := 0
+	for offset+12 <= len(buffer) {
+		raw := (*windows.FileNotifyInformation)(unsafe.Pointer(&buffer[offset]))
+		nameLength := int(raw.FileNameLength / 2)
+		if nameLength <= 0 {
+			if raw.NextEntryOffset == 0 {
+				break
+			}
+			offset += int(raw.NextEntryOffset)
+			continue
+		}
+
+		nameUnits := unsafe.Slice((*uint16)(unsafe.Pointer(&raw.FileName)), nameLength)
+		fullPath := filepath.Clean(filepath.Join(rootPath, windows.UTF16ToString(nameUnits)))
+		switch raw.Action {
+		case windows.FILE_ACTION_ADDED:
+			events = append(events, fsnotify.Event{Name: fullPath, Op: fsnotify.Create})
+		case windows.FILE_ACTION_REMOVED:
+			events = append(events, fsnotify.Event{Name: fullPath, Op: fsnotify.Remove})
+		case windows.FILE_ACTION_MODIFIED:
+			events = append(events, fsnotify.Event{Name: fullPath, Op: fsnotify.Write})
+		case windows.FILE_ACTION_RENAMED_OLD_NAME:
+			events = append(events, fsnotify.Event{Name: fullPath, Op: fsnotify.Rename})
+		case windows.FILE_ACTION_RENAMED_NEW_NAME:
+			events = append(events, fsnotify.Event{Name: fullPath, Op: fsnotify.Create})
+		}
+
+		if raw.NextEntryOffset == 0 {
+			break
+		}
+		offset += int(raw.NextEntryOffset)
+	}
+
+	return events
+}
+
+func isWindowsLibraryWatcherShutdownError(err error) bool {
+	return errors.Is(err, windows.ERROR_OPERATION_ABORTED) ||
+		errors.Is(err, windows.ERROR_INVALID_HANDLE) ||
+		errors.Is(err, windows.ERROR_ACCESS_DENIED)
+}
+
 func (w *windowsLibraryEventWatcher) watchRoot(root *windowsLibraryWatchRoot) {
 	defer w.wg.Done()
 
+	if err := root.startRead(); err != nil {
+		root.ready <- err
+		return
+	}
 	root.ready <- nil
 	for {
-		status, err := windows.WaitForMultipleObjects([]windows.Handle{w.stop, root.handle}, false, windows.INFINITE)
+		status, err := windows.WaitForMultipleObjects([]windows.Handle{w.stop, root.signal}, false, windows.INFINITE)
 		if err != nil {
 			if w.isClosed() {
 				return
@@ -110,16 +210,33 @@ func (w *windowsLibraryEventWatcher) watchRoot(root *windowsLibraryWatchRoot) {
 			return
 		}
 
-		if !w.sendEvent(fsnotify.Event{Name: root.path, Op: fsnotify.Write}) {
-			return
-		}
-
-		if err := windows.FindNextChangeNotification(root.handle); err != nil {
-			if w.isClosed() {
+		var bytesReturned uint32
+		err = windows.GetOverlappedResult(root.handle, &root.overlapped, &bytesReturned, false)
+		if err != nil {
+			if w.isClosed() && isWindowsLibraryWatcherShutdownError(err) {
 				return
 			}
+			if errors.Is(err, windows.ERROR_NOTIFY_ENUM_DIR) {
+				if !w.sendEvent(fsnotify.Event{Name: root.path, Op: fsnotify.Write}) {
+					return
+				}
+			} else {
+				w.sendError(os.NewSyscallError("GetOverlappedResult", err))
+				return
+			}
+		} else {
+			for _, event := range parseWindowsLibraryWatchEvents(root.path, root.buffer[:bytesReturned]) {
+				if !w.sendEvent(event) {
+					return
+				}
+			}
+		}
 
-			w.sendError(os.NewSyscallError("FindNextChangeNotification", err))
+		if err := root.startRead(); err != nil {
+			if w.isClosed() && isWindowsLibraryWatcherShutdownError(err) {
+				return
+			}
+			w.sendError(err)
 			return
 		}
 	}
@@ -141,14 +258,26 @@ func (w *windowsLibraryEventWatcher) Close() error {
 	if stop != 0 {
 		_ = windows.SetEvent(stop)
 	}
-	w.wg.Wait()
-
 	for _, root := range roots {
 		if root == nil || root.handle == 0 {
 			continue
 		}
-		_ = windows.FindCloseChangeNotification(root.handle)
-		root.handle = 0
+		_ = windows.CancelIoEx(root.handle, &root.overlapped)
+	}
+	w.wg.Wait()
+
+	for _, root := range roots {
+		if root == nil {
+			continue
+		}
+		if root.signal != 0 {
+			_ = windows.CloseHandle(root.signal)
+			root.signal = 0
+		}
+		if root.handle != 0 {
+			_ = windows.CloseHandle(root.handle)
+			root.handle = 0
+		}
 	}
 	if stop != 0 {
 		_ = windows.CloseHandle(stop)
@@ -167,6 +296,10 @@ func (w *windowsLibraryEventWatcher) Errors() <-chan error {
 }
 
 func (w *windowsLibraryEventWatcher) HandleCreatePath(string) {
+}
+
+func (w *windowsLibraryEventWatcher) DebounceDuration() time.Duration {
+	return windowsLibraryWatcherDebounceDuration
 }
 
 func (w *windowsLibraryEventWatcher) IsClosed() bool {

--- a/app_library_watcher_windows_test.go
+++ b/app_library_watcher_windows_test.go
@@ -33,7 +33,7 @@ func TestWindowsLibraryWatcherDoesNotLockWatchedSubfolders(t *testing.T) {
 	originalTrackPath := normalizePath(fixture.trackOne)
 	renamedTrackPath := normalizePath(filepath.Join(renamedAlbum, filepath.Base(fixture.trackOne)))
 
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(libraryWatcherUpdateTimeout)
 	for time.Now().Before(deadline) {
 		app.indexMu.Lock()
 		_, oldExists := app.trackByPath[originalTrackPath]
@@ -51,5 +51,103 @@ func TestWindowsLibraryWatcherDoesNotLockWatchedSubfolders(t *testing.T) {
 	app.indexMu.Unlock()
 	if oldExists || !newExists {
 		t.Fatalf("watcher rename update = old:%t new:%t, want old:false new:true", oldExists, newExists)
+	}
+}
+
+func TestWindowsLibraryWatcherCoalescesBurstChanges(t *testing.T) {
+	fixture := createLibraryTestFixture(t)
+	app := NewApp()
+	t.Cleanup(func() {
+		app.stopLibraryWatcher()
+	})
+
+	app.scanLibraryFolder(fixture.rootOne, false)
+	app.startLibraryWatcher([]libraryRootConfig{app.activeLibraryRoots[0]}, nil)
+	waitForLibraryWatcherToStart(t, app)
+
+	hookPaths := make(chan string, 8)
+	beforeIncrementalLibraryPathScanHook = func(path string) {
+		hookPaths <- normalizePath(path)
+	}
+	t.Cleanup(func() {
+		beforeIncrementalLibraryPathScanHook = nil
+	})
+
+	burstFolder := filepath.Join(fixture.albumOneFolder, "Burst")
+	if err := os.MkdirAll(burstFolder, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", burstFolder, err)
+	}
+
+	writeTestFile(t, filepath.Join(burstFolder, "01 One.flac"), "one")
+	time.Sleep(250 * time.Millisecond)
+	writeTestFile(t, filepath.Join(burstFolder, "02 Two.flac"), "two")
+	time.Sleep(250 * time.Millisecond)
+	writeTestFile(t, filepath.Join(burstFolder, "03 Three.flac"), "three")
+
+	select {
+	case path := <-hookPaths:
+		if path != normalizePath(burstFolder) {
+			t.Fatalf("incremental scan hook path = %q, want burst folder path %q", path, burstFolder)
+		}
+	case <-time.After(windowsLibraryWatcherDebounceDuration + 2*time.Second):
+		t.Fatal("expected a debounced root rescan after burst changes")
+	}
+
+	select {
+	case path := <-hookPaths:
+		t.Fatalf("unexpected second rescan for burst changes: %q", path)
+	case <-time.After(windowsLibraryWatcherDebounceDuration / 2):
+	}
+
+	deadline := time.Now().Add(libraryWatcherUpdateTimeout)
+	for time.Now().Before(deadline) {
+		app.indexMu.Lock()
+		_, oneExists := app.trackByPath[normalizePath(filepath.Join(burstFolder, "01 One.flac"))]
+		_, twoExists := app.trackByPath[normalizePath(filepath.Join(burstFolder, "02 Two.flac"))]
+		_, threeExists := app.trackByPath[normalizePath(filepath.Join(burstFolder, "03 Three.flac"))]
+		app.indexMu.Unlock()
+		if oneExists && twoExists && threeExists {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("burst changes were not fully indexed after the debounced root rescan")
+}
+
+func TestWindowsLibraryWatcherTargetsCoverArtChanges(t *testing.T) {
+	fixture := createLibraryTestFixture(t)
+	app := NewApp()
+	t.Cleanup(func() {
+		app.stopLibraryWatcher()
+	})
+
+	app.scanLibraryFolder(fixture.rootOne, false)
+	app.startLibraryWatcher([]libraryRootConfig{app.activeLibraryRoots[0]}, nil)
+	waitForLibraryWatcherToStart(t, app)
+
+	hookPaths := make(chan string, 8)
+	beforeIncrementalLibraryPathScanHook = func(path string) {
+		hookPaths <- normalizePath(path)
+	}
+	t.Cleanup(func() {
+		beforeIncrementalLibraryPathScanHook = nil
+	})
+
+	writeTestFile(t, fixture.coverOne, "updated-cover")
+
+	select {
+	case path := <-hookPaths:
+		albumFolder := normalizePath(filepath.Dir(fixture.coverOne))
+		coverPath := normalizePath(fixture.coverOne)
+		rootPath := normalizePath(fixture.rootOne)
+		if path == rootPath {
+			t.Fatalf("incremental scan hook path = %q, want targeted cover update instead of root rescan", path)
+		}
+		if path != albumFolder && path != coverPath {
+			t.Fatalf("incremental scan hook path = %q, want album folder %q or cover file %q", path, albumFolder, coverPath)
+		}
+	case <-time.After(windowsLibraryWatcherDebounceDuration + 2*time.Second):
+		t.Fatal("expected a targeted incremental rescan after replacing cover art")
 	}
 }

--- a/app_library_watcher_windows_test.go
+++ b/app_library_watcher_windows_test.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWindowsLibraryWatcherDoesNotLockWatchedSubfolders(t *testing.T) {
+	fixture := createLibraryTestFixture(t)
+	app := NewApp()
+	t.Cleanup(func() {
+		app.stopLibraryWatcher()
+	})
+
+	app.scanLibraryFolder(fixture.rootOne, false)
+	if len(app.activeLibraryRoots) != 1 {
+		t.Fatalf("activeLibraryRoots len = %d, want 1", len(app.activeLibraryRoots))
+	}
+
+	app.startLibraryWatcher([]libraryRootConfig{app.activeLibraryRoots[0]}, nil)
+	waitForLibraryWatcherToStart(t, app)
+
+	originalAlbum := fixture.albumOneFolder
+	renamedAlbum := filepath.Join(filepath.Dir(originalAlbum), "Album One Renamed")
+	if err := os.Rename(originalAlbum, renamedAlbum); err != nil {
+		t.Fatalf("Rename(%q, %q) error = %v", originalAlbum, renamedAlbum, err)
+	}
+
+	originalTrackPath := normalizePath(fixture.trackOne)
+	renamedTrackPath := normalizePath(filepath.Join(renamedAlbum, filepath.Base(fixture.trackOne)))
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		app.indexMu.Lock()
+		_, oldExists := app.trackByPath[originalTrackPath]
+		_, newExists := app.trackByPath[renamedTrackPath]
+		app.indexMu.Unlock()
+		if !oldExists && newExists {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	app.indexMu.Lock()
+	_, oldExists := app.trackByPath[originalTrackPath]
+	_, newExists := app.trackByPath[renamedTrackPath]
+	app.indexMu.Unlock()
+	if oldExists || !newExists {
+		t.Fatalf("watcher rename update = old:%t new:%t, want old:false new:true", oldExists, newExists)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	go.senan.xyz/taglib v0.11.1
 	golang.design/x/clipboard v0.7.1
 	golang.org/x/image v0.28.0
+	golang.org/x/sys v0.42.0
 	modernc.org/sqlite v1.48.1
 )
 
@@ -59,7 +60,6 @@ require (
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
 	golang.org/x/net v0.35.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/musicbrainz_tag_db_query.go
+++ b/musicbrainz_tag_db_query.go
@@ -108,14 +108,9 @@ func (a *App) isMusicBrainzTagSearchFolderAvailableLocked(folderPath string) boo
 	if cleanFolderPath == "" {
 		return false
 	}
-	scanState := a.libraryScanState()
 	indexState := a.libraryIndexState()
 
-	if !scanState.scanInProgress {
-		a.maybeStartLibraryDerivedIndexRebuildLocked()
-	}
-
-	if a.isLibraryDerivedIndexReadyLocked() {
+	if a.isLibraryFolderIndexReadyLocked() {
 		_, exists := indexState.folderEntriesByFolder[cleanFolderPath]
 		return exists
 	}
@@ -143,7 +138,7 @@ func (a *App) buildMusicBrainzTagSearchResultsLocked(tagNames []string) []Librar
 	appendFolderEntries := func(folderPath string) {
 		var folderEntries []LibraryBrowserEntry
 		indexState := a.libraryIndexState()
-		if a.isLibraryDerivedIndexReadyLocked() {
+		if a.isLibraryFolderIndexReadyLocked() {
 			folderEntries = indexState.folderEntriesByFolder[folderPath]
 		} else {
 			folderEntries = a.buildFolderEntriesFromMapsLocked(folderPath)


### PR DESCRIPTION
This PR is not the end state for the library update pipeline. It is an interim reduction in cost when a localized filesystem change is detected, aimed at lowering the CPU, lock contention, and disk I/O burden of small watcher-driven updates rather than fully solving the broader performance issues.

The changes keep more work incremental, avoid some unnecessary global rebuilds, and reduce full-database rewrite behavior after small updates. The result should be lighter resource pressure during localized updates, but more work is still needed before this area can be considered fully fixed.