### PR TITLE
Handle audio refresh fallbacks

### DIFF
--- a/audio_backend.go
+++ b/audio_backend.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -314,6 +315,23 @@ func (b *AudioBackend) flushPlayerBuffer(player audioOutputPlayer) error {
 	return nil
 }
 
+func (b *AudioBackend) selectedOutputDeviceIDLocked() string {
+	selectedOutputDevice := strings.TrimSpace(b.outputDevice)
+	if selectedOutputDevice == "" || selectedOutputDevice == defaultAudioOutputDevice {
+		return ""
+	}
+
+	for _, device := range b.ListOutputDevices() {
+		if strings.TrimSpace(device.ID) == selectedOutputDevice {
+			return selectedOutputDevice
+		}
+	}
+
+	logAudioEvent("Initialize falling back to default audio output because device=%q is unavailable", selectedOutputDevice)
+	b.outputDevice = defaultAudioOutputDevice
+	return ""
+}
+
 // SetFFmpegPath updates the configured ffmpeg executable path used by the backend.
 func (b *AudioBackend) SetFFmpegPath(path string) {
 	b.mutex.Lock()
@@ -445,18 +463,14 @@ func (b *AudioBackend) Initialize() error {
 		return nil
 	}
 
-	context, ready, err := newAudioOutputContext(&oto.NewContextOptions{
-		SampleRate:   audioSampleRate,
-		ChannelCount: audioChannelCount,
-		Format:       oto.FormatSignedInt16LE,
-		BufferSize:   b.outputBuffer,
-		OutputDeviceID: func() string {
-			if b.outputDevice == "" || b.outputDevice == defaultAudioOutputDevice {
-				return ""
-			}
+	selectedOutputDeviceID := b.selectedOutputDeviceIDLocked()
 
-			return b.outputDevice
-		}(),
+	context, ready, err := newAudioOutputContext(&oto.NewContextOptions{
+		SampleRate:     audioSampleRate,
+		ChannelCount:   audioChannelCount,
+		Format:         oto.FormatSignedInt16LE,
+		BufferSize:     b.outputBuffer,
+		OutputDeviceID: selectedOutputDeviceID,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize audio output: %w", err)

--- a/audio_backend_runtime_test.go
+++ b/audio_backend_runtime_test.go
@@ -194,6 +194,33 @@ func TestAudioBackendInitializeCloseAndOutputDevices(t *testing.T) {
 		t.Fatal("Initialize(context failure) error = nil, want error")
 	}
 
+	capturedOutputDeviceID := ""
+	originalNewAudioOutputContext := newAudioOutputContext
+	newAudioOutputContext = func(options *oto.NewContextOptions) (audioOutputContext, <-chan struct{}, error) {
+		capturedOutputDeviceID = options.OutputDeviceID
+		ready := make(chan struct{})
+		close(ready)
+		return &fakeAudioContext{}, ready, nil
+	}
+	t.Cleanup(func() {
+		newAudioOutputContext = originalNewAudioOutputContext
+	})
+	listAudioOutputDevices = func() ([]oto.OutputDevice, error) {
+		return []oto.OutputDevice{{ID: "replacement-device", Name: "Speakers", Backend: "wasapi", IsDefault: true}}, nil
+	}
+	backendWithMissingDevice := NewAudioBackend()
+	backendWithMissingDevice.ffmpegPath = helperPath
+	backendWithMissingDevice.outputDevice = "missing-device"
+	if err := backendWithMissingDevice.Initialize(); err != nil {
+		t.Fatalf("Initialize(missing selected device) error = %v", err)
+	}
+	if capturedOutputDeviceID != "" {
+		t.Fatalf("Initialize(missing selected device) OutputDeviceID = %q, want empty string for default fallback", capturedOutputDeviceID)
+	}
+	if backendWithMissingDevice.outputDevice != defaultAudioOutputDevice {
+		t.Fatalf("Initialize(missing selected device) outputDevice = %q, want %q", backendWithMissingDevice.outputDevice, defaultAudioOutputDevice)
+	}
+
 	if err := NewAudioBackend().Close(); err != nil {
 		t.Fatalf("Close(nil context) error = %v, want nil", err)
 	}

--- a/frontend/src/app-controller-setup.test.ts
+++ b/frontend/src/app-controller-setup.test.ts
@@ -340,7 +340,11 @@ describe('app-controller-setup', () => {
         await expect(settingsConfig.fetchLastFmSessionKey(' key ', ' secret ')).rejects.toThrow('Last.fm authorization was cancelled.');
         context.openQueueConfirmModal.mockResolvedValueOnce(true);
         expect(await settingsConfig.fetchLastFmSessionKey(' key ', ' secret ')).toBe('session-key');
-        expect(await settingsConfig.applyAudioNow(saveValues)).toEqual([{ id: 'usb', name: 'USB DAC', backend: 'wasapi', isDefault: false }]);
+        expect(await settingsConfig.applyAudioNow(saveValues)).toEqual({
+            devices: [{ id: 'usb', name: 'USB DAC', backend: 'wasapi', isDefault: false }],
+            selectedDevice: 'default',
+            message: 'Audio settings refreshed.',
+        });
         await settingsConfig.forceReload();
         context.ffmpegConfigurationRequired = false;
         expect(await settingsConfig.beforeClose()).toBeNull();
@@ -451,5 +455,77 @@ describe('app-controller-setup', () => {
         expect(context.openSidebarQueueMenu).toHaveBeenCalledWith(30, 40, [0], undefined, false, '', '/music/library', 'Library', true, true, undefined);
         expect(context.openSidebarQueueMenu).toHaveBeenCalledWith(50, 60, [], undefined, false, '', '/music/library', 'Library', true, false, undefined);
         expect(context.closeSidebarQueueMenu).toHaveBeenCalled();
+    });
+
+    it('falls back to the default output device when the refreshed list no longer contains the saved device', async () => {
+        createSettingsControllerMock.mockImplementation((config) => ({ config }));
+        createPlaylistControllerMock.mockReturnValue({
+            refreshFavorites: vi.fn(),
+            activatePlaybackQueueSource: vi.fn(),
+        });
+        createPlaylistTargetModalControllerMock.mockReturnValue({ modal: true });
+        createShareControllerMock.mockReturnValue({ share: true });
+        createImageModalControllerMock.mockReturnValue({ openImageFile: vi.fn() });
+        createArtistInfoControllerMock.mockReturnValue({ artist: true });
+        createLibraryControllerMock.mockReturnValue({ library: true });
+
+        const context = createContext();
+        context.refreshAvailableAudioOutputDevices.mockResolvedValueOnce([
+            { id: 'fresh-device', name: 'USB DAC', backend: 'wasapi', isDefault: false },
+        ]);
+
+        setupAppControllers(context as unknown as AppControllerSetupContext);
+        const settingsConfig = createSettingsControllerMock.mock.calls.at(-1)?.[0];
+
+        const applyValues = {
+            libraryFolders: [{ path: '/music/library', label: 'Library', releaseDepth: 1 }],
+            localLibraryFilesDatabaseEnabled: true,
+            localLibraryFilesDatabaseLoadOnStartup: true,
+            localLibraryFilesDatabaseListenHistoryEnabled: false,
+            localLibraryFilesDatabaseListenHistoryLimit: 0,
+            ffmpegPath: 'ffmpeg',
+            listenBrainzUserToken: 'token',
+            lastFmApiKey: 'key',
+            lastFmApiSecret: 'secret',
+            lastFmSessionKey: 'session',
+            scrobbleFilterMode: 'blacklist',
+            scrobbleRules: [],
+            musicBrainzServerUrl: '',
+            musicBrainzRequestRateMs: 1000,
+            listenBrainzServerUrl: '',
+            listenBrainzRequestRateMs: 1000,
+            favoritePlaylists: ['favorites.m3u'],
+            coverArtPriority: ['file', 'embedded'],
+            audioOutputDevice: 'stale-device',
+            audioOutputBufferMs: 64,
+            gaplessPlayback: false,
+            replayGainEnabled: true,
+            preferMusicBrainzMetadata: false,
+            musicBrainzTagDatabaseEnabled: false,
+            highlightMusicBrainzTaggedAlbumFolders: false,
+            musicBrainzTagStaleDays: 30,
+            musicBrainzTagRequestStaggeringEnabled: false,
+            musicBrainzTagWorkerCores: 2,
+            lissajousEnabled: true,
+            lissajousScale: 0.4,
+            visualizerMode: 'equalizer',
+            equalizerPosition: 'top',
+            uiDitheringEnabled: true,
+            minimizeToTrayOnClose: false,
+            customSendToActions: [],
+            keyboardShortcuts: defaultAppSettings.keyboardShortcuts,
+        };
+
+        const result = await settingsConfig.applyAudioNow(applyValues);
+
+        expect(result).toEqual({
+            devices: [{ id: 'fresh-device', name: 'USB DAC', backend: 'wasapi', isDefault: false }],
+            selectedDevice: 'default',
+            message: 'Audio settings refreshed. Switched to Primary Sound Driver because the selected audio device is unavailable.',
+        });
+        expect(context.saveSettings).toHaveBeenCalledWith(expect.objectContaining({
+            audio: expect.objectContaining({ outputDevice: 'default' }),
+        }));
+        expect(context.audioReinitializeBackend).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/src/app-settings-controller-setup.ts
+++ b/frontend/src/app-settings-controller-setup.ts
@@ -14,6 +14,28 @@ import type { SettingsControllerState } from './controllers/settings-controller-
 import { normalizeLibraryFolders } from './utils/main-helpers';
 import { normalizeAppSettings } from './utils/settings-normalization';
 
+const defaultAudioOutputDeviceId = 'default';
+
+const resolveAvailableAudioOutputDevice = (
+    requestedDevice: string,
+    outputDevices: AudioOutputDevice[],
+): { selectedDevice: string; fellBackToDefault: boolean } => {
+    const normalizedRequestedDevice = requestedDevice.trim() || defaultAudioOutputDeviceId;
+    if (normalizedRequestedDevice === defaultAudioOutputDeviceId) {
+        return { selectedDevice: defaultAudioOutputDeviceId, fellBackToDefault: false };
+    }
+
+    const deviceExists = outputDevices.some((device) => {
+        const normalizedDeviceID = (device.id || defaultAudioOutputDeviceId).trim() || defaultAudioOutputDeviceId;
+        return normalizedDeviceID === normalizedRequestedDevice;
+    });
+    if (deviceExists) {
+        return { selectedDevice: normalizedRequestedDevice, fellBackToDefault: false };
+    }
+
+    return { selectedDevice: defaultAudioOutputDeviceId, fellBackToDefault: true };
+};
+
 export interface AppSettingsControllerSetupContext {
     trigger: HTMLButtonElement;
     elements: SettingsModalElements;
@@ -261,9 +283,14 @@ export const setupSettingsController = (context: AppSettingsControllerSetupConte
 
             return await context.getLastFmSessionKey(normalizedApiKey, normalizedApiSecret, requestToken);
         },
-        applyAudioNow: async (values): Promise<AudioOutputDevice[]> => {
-            await saveNormalizedSettings(values);
+        applyAudioNow: async (values) => {
             const outputDevices = await context.refreshAvailableAudioOutputDevices();
+            const resolvedOutputDevice = resolveAvailableAudioOutputDevice(values.audioOutputDevice, outputDevices);
+            const nextValues = resolvedOutputDevice.fellBackToDefault
+                ? { ...values, audioOutputDevice: resolvedOutputDevice.selectedDevice }
+                : values;
+
+            await saveNormalizedSettings(nextValues);
 
             const nextState = await context.audioReinitializeBackend();
             context.setPlaybackBackendReady(true);
@@ -278,7 +305,13 @@ export const setupSettingsController = (context: AppSettingsControllerSetupConte
             }
 
             void context.refreshListenBrainzFeedbackForCurrentTrack(true);
-            return outputDevices;
+            return {
+                devices: outputDevices,
+                selectedDevice: resolvedOutputDevice.selectedDevice,
+                message: resolvedOutputDevice.fellBackToDefault
+                    ? 'Audio settings refreshed. Switched to Primary Sound Driver because the selected audio device is unavailable.'
+                    : 'Audio settings refreshed.',
+            };
         },
         forceReload: async (): Promise<void> => {
             await context.scanConfiguredLibraryFolders();

--- a/frontend/src/controllers/settings-controller-events.test.ts
+++ b/frontend/src/controllers/settings-controller-events.test.ts
@@ -3,6 +3,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getSettingsModalElements, renderSettingsModal } from '../components/overlays/settings-modal';
 import { bindSettingsControllerEvents, type SettingsControllerEventContext } from './settings-controller-events';
 
+const flushPromises = async (): Promise<void> => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+};
+
 const createContext = (): SettingsControllerEventContext => {
     document.body.innerHTML = renderSettingsModal();
     const trigger = document.createElement('button');
@@ -17,7 +23,7 @@ const createContext = (): SettingsControllerEventContext => {
             selectPlaylistFile: vi.fn(async () => ''),
             save: vi.fn(async () => undefined),
             fetchLastFmSessionKey: vi.fn(async () => ''),
-            applyAudioNow: vi.fn(async () => []),
+            applyAudioNow: vi.fn(async () => ({ devices: [], selectedDevice: 'default', message: 'Audio settings refreshed.' })),
             forceReload: vi.fn(async () => undefined),
             getPlayerCardLayout: vi.fn(() => 'default'),
             setPlayerCardLayout: vi.fn(),
@@ -143,5 +149,21 @@ describe('bindSettingsControllerEvents', () => {
         (tooltipTrigger as HTMLButtonElement).click();
 
         expect(context.setShortcutAccordionExpanded).not.toHaveBeenCalled();
+    });
+
+    it('surfaces the underlying refresh-audio failure reason', async () => {
+        const context = createContext();
+        context.options.applyAudioNow = vi.fn(async () => {
+            throw new Error('audio output context failed: oto: device not found');
+        });
+        bindSettingsControllerEvents(context);
+
+        context.elements.settingsApplyAudioNow.click();
+        await flushPromises();
+
+        expect(context.setSettingsStatusMessage).toHaveBeenCalledWith('Refreshing audio settings...');
+        expect(context.setSettingsStatusMessage).toHaveBeenCalledWith(
+            'Unable to refresh audio settings right now: audio output context failed: oto: device not found',
+        );
     });
 });

--- a/frontend/src/controllers/settings-controller-events.ts
+++ b/frontend/src/controllers/settings-controller-events.ts
@@ -15,6 +15,7 @@ import {
     normalizeScrobbleRules,
     validateScrobbleRules,
 } from '../utils/main-helpers';
+import { errorMessage } from '../utils/display-helpers';
 import type {
     LibraryFolderDialogValues,
     ScrobbleRuleDialogValues,
@@ -546,12 +547,15 @@ export const bindSettingsControllerEvents = (context: SettingsControllerEventCon
                 throw new Error(validationMessage);
             }
 
-            const refreshedDevices = await options.applyAudioNow(formValues);
-            refreshAudioOutputDevices(refreshedDevices, formValues.audioOutputDevice || 'default');
-            setSettingsStatusMessage('Audio settings refreshed.');
+            const refreshedAudioState = await options.applyAudioNow(formValues);
+            refreshAudioOutputDevices(refreshedAudioState.devices, refreshedAudioState.selectedDevice || 'default');
+            setSettingsStatusMessage(refreshedAudioState.message || 'Audio settings refreshed.');
         } catch (error) {
             console.error(error);
-            setSettingsStatusMessage('Unable to refresh audio settings right now.');
+            const message = errorMessage(error).trim();
+            setSettingsStatusMessage(message === ''
+                ? 'Unable to refresh audio settings right now.'
+                : `Unable to refresh audio settings right now: ${message}`);
         } finally {
             settingsApplyAudioNow.disabled = false;
         }

--- a/frontend/src/controllers/settings-controller-types.ts
+++ b/frontend/src/controllers/settings-controller-types.ts
@@ -62,6 +62,12 @@ export type SettingsViewValues = SettingsFormValues & {
     musicBrainzTagWorkerProgress: MusicBrainzTagWorkerProgress;
 };
 
+export type ApplyAudioNowResult = {
+    devices: AudioOutputDevice[];
+    selectedDevice: string;
+    message?: string;
+};
+
 export type SettingsPrimaryTab = 'general' | 'library' | 'network' | 'playlists' | 'scrobbling' | 'audio' | 'ui' | 'actions';
 export type SettingsTab = SettingsPrimaryTab | 'database' | 'shortcuts';
 
@@ -74,7 +80,7 @@ export type SettingsControllerOptions = {
     selectPlaylistFile: () => Promise<string>;
     save: (values: SettingsFormValues) => Promise<void>;
     fetchLastFmSessionKey: (apiKey: string, apiSecret: string) => Promise<string>;
-    applyAudioNow: (values: SettingsFormValues) => Promise<AudioOutputDevice[]>;
+    applyAudioNow: (values: SettingsFormValues) => Promise<ApplyAudioNowResult>;
     forceReload: (values: SettingsFormValues) => Promise<void>;
     beforeClose?: () => Promise<string | null>;
     onCloseBlocked?: (message: string) => void;

--- a/frontend/src/controllers/settings-controller.test.ts
+++ b/frontend/src/controllers/settings-controller.test.ts
@@ -14,6 +14,12 @@ const createAudioDevices = (): AudioOutputDevice[] => ([
     { id: 'device-1', name: 'USB DAC', backend: 'wasapi', isDefault: false },
 ]);
 
+const createApplyAudioNowResult = () => ({
+    devices: createAudioDevices(),
+    selectedDevice: 'device-1',
+    message: 'Audio settings refreshed.',
+});
+
 const createKeyboardShortcuts = (): FocusedKeyboardShortcuts => ({
     playPauseToggle: 'Space',
     nextTrack: 'N',
@@ -91,7 +97,7 @@ const mountSettingsController = (options: {
     const save = options.save ?? vi.fn(async () => undefined);
     const forceReload = options.forceReload ?? vi.fn(async () => undefined);
     const fetchLastFmSessionKey = options.fetchLastFmSessionKey ?? vi.fn(async () => 'session-key');
-    const applyAudioNow = vi.fn(async () => createAudioDevices());
+    const applyAudioNow = vi.fn(async () => createApplyAudioNowResult());
     const setPlayerCardLayout = vi.fn((_layout: PlayerCardLayout) => undefined);
 
     const controller = createSettingsController({

--- a/frontend/src/main.test.ts
+++ b/frontend/src/main.test.ts
@@ -266,6 +266,7 @@ vi.mock('../wailsjs/go/main/App', () => ({
     AppendTracksToPlaylistFile: vi.fn(async () => true),
     AudioListOutputDevices: vi.fn(async () => []),
     AudioQueueNextTrack: vi.fn(async () => undefined),
+    AudioReinitializeBackend: vi.fn(async () => ({ loaded: false })),
     AudioSeek: vi.fn(async () => ({ loaded: false })),
     AudioSetVolume: vi.fn(async () => ({ loaded: false })),
     AudioStop: vi.fn(async () => ({ loaded: false })),
@@ -362,5 +363,17 @@ describe('main entrypoint runtime scope', () => {
         }
 
         expect(scope?.isSeeking).toBe(true);
+    });
+
+    it('exposes audioReinitializeBackend on the runtime scope passed to controller setup', async () => {
+        await import('./main');
+
+        const scope = testState.getControllerScope() as {
+            audioReinitializeBackend?: () => Promise<unknown>;
+        } | null;
+
+        expect(scope).not.toBeNull();
+        expect(scope?.audioReinitializeBackend).toBeTypeOf('function');
+        await expect(scope?.audioReinitializeBackend?.()).resolves.toEqual({ loaded: false });
     });
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,6 +7,7 @@ import { UI_TIMINGS_MS } from './constants/ui-timings';
 import {
     ScanConfiguredLibraryFolders,
     AudioListOutputDevices,
+    AudioReinitializeBackend,
     AppendTracksToPlaylistFile,
     CopyShareImageToClipboard,
     GetMusicBrainzTagWorkerProgress,
@@ -303,6 +304,7 @@ const runtimePorts = {
     scanConfiguredLibraryFoldersBackend: async (): Promise<LibraryScanResult> => await ScanConfiguredLibraryFolders() as LibraryScanResult,
     audioStop: async (): Promise<AudioPlaybackState> => await AudioStop() as AudioPlaybackState,
     listAudioOutputDevices: async (): Promise<AudioOutputDevice[]> => await AudioListOutputDevices() as AudioOutputDevice[],
+    audioReinitializeBackend: async (): Promise<AudioPlaybackState> => await AudioReinitializeBackend() as AudioPlaybackState,
     getSettings: async (): Promise<AppSettings> => await GetSettings() as unknown as AppSettings,
     getMusicBrainzTagWorkerProgress: async (): Promise<MusicBrainzTagWorkerProgress> => await GetMusicBrainzTagWorkerProgress() as MusicBrainzTagWorkerProgress,
     getAppVersion: async (): Promise<string> => await GetAppVersion(),


### PR DESCRIPTION
Fall back to the default output device when a saved device disappears, surface the concrete refresh error, and wire the frontend runtime reinitialize binding. Validated with npm run validate:ci.