### PR TITLE
Tighten initial volume tooltip hover hitbox

### DIFF
--- a/frontend/src/app-event-bindings.test.ts
+++ b/frontend/src/app-event-bindings.test.ts
@@ -13,6 +13,13 @@ const flushPromises = async (): Promise<void> => {
     await Promise.resolve();
 };
 
+const volumeControlMarkup = (value: number): string => `
+    <div class="volume-wrap">
+        <button id="volume-btn" type="button"><svg class="control-icon" viewBox="0 0 24 24" aria-hidden="true"></svg></button>
+        <div class="volume-popout"><input id="volume" type="range" min="0" max="1" value="${value}" step="0.01"></div>
+    </div>
+`;
+
 describe('setupVolumeControlBindings', () => {
     beforeEach(() => {
         vi.useFakeTimers();
@@ -25,12 +32,7 @@ describe('setupVolumeControlBindings', () => {
     });
 
     it('mutes and restores volume on button click without toggling popout state', async () => {
-        document.body.innerHTML = `
-            <div class="volume-wrap">
-                <button id="volume-btn" type="button"></button>
-                <div class="volume-popout"><input id="volume" type="range" min="0" max="1" value="0.8" step="0.01"></div>
-            </div>
-        `;
+        document.body.innerHTML = volumeControlMarkup(0.8);
 
         const volume = document.querySelector('#volume') as HTMLInputElement;
         const volumeBtn = document.querySelector('#volume-btn') as HTMLButtonElement;
@@ -75,16 +77,12 @@ describe('setupVolumeControlBindings', () => {
         expect(volumeBtn.getAttribute('aria-label')).toBe('Unmute');
     });
 
-    it('keeps popout open while hovered and closes after leaving for about half a second', () => {
-        document.body.innerHTML = `
-            <div class="volume-wrap">
-                <button id="volume-btn" type="button"></button>
-                <div class="volume-popout"><input id="volume" type="range" min="0" max="1" value="0.6" step="0.01"></div>
-            </div>
-        `;
+    it('opens only from the icon hitbox, then keeps the wider hover area until hidden', () => {
+        document.body.innerHTML = volumeControlMarkup(0.6);
 
         const volume = document.querySelector('#volume') as HTMLInputElement;
         const volumeBtn = document.querySelector('#volume-btn') as HTMLButtonElement;
+        const volumeIcon = volumeBtn.querySelector('.control-icon') as SVGElement;
 
         const volumeRow = setupVolumeControlBindings({
             document,
@@ -96,23 +94,30 @@ describe('setupVolumeControlBindings', () => {
         });
 
         volumeRow.dispatchEvent(new Event('pointerenter', { bubbles: true }));
+        expect(volumeRow.classList.contains('open')).toBe(false);
+
+        volumeIcon.dispatchEvent(new Event('pointerenter', { bubbles: true }));
+        expect(volumeRow.classList.contains('open')).toBe(true);
+
+        volumeRow.dispatchEvent(new Event('pointerenter', { bubbles: true }));
         expect(volumeRow.classList.contains('open')).toBe(true);
 
         volumeRow.dispatchEvent(new Event('pointerleave', { bubbles: true }));
-        vi.advanceTimersByTime(450);
+        vi.advanceTimersByTime(250);
+        volumeRow.dispatchEvent(new Event('pointerenter', { bubbles: true }));
+        vi.advanceTimersByTime(400);
         expect(volumeRow.classList.contains('open')).toBe(true);
 
-        vi.advanceTimersByTime(60);
+        volumeRow.dispatchEvent(new Event('pointerleave', { bubbles: true }));
+        vi.advanceTimersByTime(510);
+        expect(volumeRow.classList.contains('open')).toBe(false);
+
+        volumeRow.dispatchEvent(new Event('pointerenter', { bubbles: true }));
         expect(volumeRow.classList.contains('open')).toBe(false);
     });
 
     it('adjusts volume with mouse wheel over the volume button', async () => {
-        document.body.innerHTML = `
-            <div class="volume-wrap">
-                <button id="volume-btn" type="button"></button>
-                <div class="volume-popout"><input id="volume" type="range" min="0" max="1" value="0.5" step="0.01"></div>
-            </div>
-        `;
+        document.body.innerHTML = volumeControlMarkup(0.5);
 
         const volume = document.querySelector('#volume') as HTMLInputElement;
         const volumeBtn = document.querySelector('#volume-btn') as HTMLButtonElement;

--- a/frontend/src/app-event-bindings.ts
+++ b/frontend/src/app-event-bindings.ts
@@ -33,6 +33,7 @@ export const setupVolumeControlBindings = (context: VolumeControlBindingsContext
     } = context;
 
     const volumeRow = volumeBtn.closest('.volume-wrap') as HTMLElement;
+    const volumeHoverTarget = volumeBtn.querySelector('.control-icon') as HTMLElement | null;
     const HIDE_DELAY_MS = 500;
     const WHEEL_STEP = 0.05;
     let closeTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -54,6 +55,8 @@ export const setupVolumeControlBindings = (context: VolumeControlBindingsContext
         clearCloseTimeout();
         volumeRow.classList.add('open');
     };
+
+    const isVolumePopoutOpen = (): boolean => volumeRow.classList.contains('open');
 
     const queueCloseVolumePopout = (): void => {
         clearCloseTimeout();
@@ -112,7 +115,15 @@ export const setupVolumeControlBindings = (context: VolumeControlBindingsContext
         setVolume(nextVolume);
     }, { passive: false });
 
+    (volumeHoverTarget ?? volumeBtn).addEventListener('pointerenter', () => {
+        showVolumePopout();
+    });
+
     volumeRow.addEventListener('pointerenter', () => {
+        if (!isVolumePopoutOpen()) {
+            return;
+        }
+
         showVolumePopout();
     });
 


### PR DESCRIPTION
Enhance the volume control interaction by adjusting the hover area for the tooltip. The tooltip now opens only from the icon hitbox and maintains a wider hover area until hidden.

Resolves #53.