### PR TITLE
Increase audio playback headroom

### DIFF
--- a/audio_backend.go
+++ b/audio_backend.go
@@ -14,14 +14,20 @@ import (
 )
 
 const (
-	audioSampleRate                 = 44100
-	audioChannelCount               = 2
-	audioBytesPerFrame              = audioChannelCount * 2
-	minVisualizationFrameCount      = 64
-	maxVisualizationFrameCount      = 2048
-	visualizationWindowFactor       = 6
-	longVisualizationFrameThreshold = 768
-	longVisualizationWindowSeconds  = 10
+	audioSampleRate                  = 44100
+	audioChannelCount                = 2
+	audioBytesPerFrame               = audioChannelCount * 2
+	defaultAudioOutputBuffer         = 256 * time.Millisecond
+	defaultAudioPlayerBuffer         = 1500 * time.Millisecond
+	maxAudioPlayerBuffer             = 3 * time.Second
+	playerBufferHeadroomFactor       = 4
+	playbackHeadroomLowThreshold     = 150 * time.Millisecond
+	playbackHeadroomRecoverThreshold = 500 * time.Millisecond
+	minVisualizationFrameCount       = 64
+	maxVisualizationFrameCount       = 2048
+	visualizationWindowFactor        = 6
+	longVisualizationFrameThreshold  = 768
+	longVisualizationWindowSeconds   = 10
 )
 
 var audioBytesPerSecond = audioSampleRate * audioBytesPerFrame
@@ -97,6 +103,8 @@ func (s *audioPlayerSource) Seek(offset int64, whence int) (int64, error) {
 
 type audioOutputPlayer interface {
 	SetVolume(volume float64)
+	SetBufferSize(bufferSize int)
+	BufferedSize() int
 	Play()
 	Pause()
 	Err() error
@@ -111,6 +119,8 @@ type audioOutputContext interface {
 
 type otoPlayerAdapter struct {
 	setVolume func(volume float64)
+	setBuffer func(bufferSize int)
+	buffered  func() int
 	play      func()
 	pause     func()
 	err       func() error
@@ -121,6 +131,20 @@ func (a *otoPlayerAdapter) SetVolume(volume float64) {
 	if a.setVolume != nil {
 		a.setVolume(volume)
 	}
+}
+
+func (a *otoPlayerAdapter) SetBufferSize(bufferSize int) {
+	if a.setBuffer != nil {
+		a.setBuffer(bufferSize)
+	}
+}
+
+func (a *otoPlayerAdapter) BufferedSize() int {
+	if a.buffered == nil {
+		return 0
+	}
+
+	return a.buffered()
 }
 
 func (a *otoPlayerAdapter) Play() {
@@ -192,6 +216,8 @@ var newAudioOutputContext = func(options *oto.NewContextOptions) (audioOutputCon
 			player := context.NewPlayer(source)
 			return &otoPlayerAdapter{
 				setVolume: player.SetVolume,
+				setBuffer: player.SetBufferSize,
+				buffered:  player.BufferedSize,
 				play:      player.Play,
 				pause:     player.Pause,
 				err:       player.Err,
@@ -223,6 +249,7 @@ type AudioBackend struct {
 	outputBuffer                time.Duration
 	gaplessPlayback             bool
 	replayGainEnabled           bool
+	playbackHeadroomLow         bool
 	replayGainCacheMu           sync.Mutex
 	replayGainCacheByPath       map[string]replayGainCacheEntry
 	replayGainCacheOrder        []string
@@ -265,6 +292,111 @@ func normalizeReplayGainScale(scale float64) float64 {
 	}
 
 	return scale
+}
+
+func durationToAlignedAudioBytes(duration time.Duration) int {
+	if duration <= 0 {
+		return 0
+	}
+
+	byteCount := int((duration * time.Duration(audioBytesPerSecond)) / time.Second)
+	if byteCount <= 0 {
+		return 0
+	}
+
+	remainder := byteCount % audioBytesPerFrame
+	if remainder != 0 {
+		byteCount += audioBytesPerFrame - remainder
+	}
+
+	return byteCount
+}
+
+func audioDurationForByteCount(byteCount int64) time.Duration {
+	if byteCount <= 0 {
+		return 0
+	}
+
+	return (time.Duration(byteCount) * time.Second) / time.Duration(audioBytesPerSecond)
+}
+
+func (b *AudioBackend) effectiveOutputBufferLocked() time.Duration {
+	if b.outputBuffer > 0 {
+		return b.outputBuffer
+	}
+
+	return defaultAudioOutputBuffer
+}
+
+func (b *AudioBackend) desiredPlayerBufferSizeLocked() int {
+	target := defaultAudioPlayerBuffer
+	headroomTarget := b.effectiveOutputBufferLocked() * playerBufferHeadroomFactor
+	if headroomTarget > target {
+		target = headroomTarget
+	}
+	if target > maxAudioPlayerBuffer {
+		target = maxAudioPlayerBuffer
+	}
+
+	return durationToAlignedAudioBytes(target)
+}
+
+func (b *AudioBackend) playerBufferedBytesLocked() int64 {
+	if b.player == nil {
+		return 0
+	}
+
+	bufferedBytes := int64(b.player.BufferedSize())
+	if bufferedBytes < 0 {
+		return 0
+	}
+	if bufferedBytes > b.streamReadOffset {
+		return b.streamReadOffset
+	}
+
+	return bufferedBytes
+}
+
+func (b *AudioBackend) reportPlaybackHeadroomLocked() {
+	if !b.playing || len(b.streamSegments) == 0 || b.player == nil {
+		b.playbackHeadroomLow = false
+		return
+	}
+
+	bufferedDuration := audioDurationForByteCount(b.playerBufferedBytesLocked())
+	lowThreshold := playbackHeadroomLowThreshold
+	if derivedThreshold := b.effectiveOutputBufferLocked() / 2; derivedThreshold > lowThreshold {
+		lowThreshold = derivedThreshold
+	}
+	recoverThreshold := playbackHeadroomRecoverThreshold
+	if derivedThreshold := b.effectiveOutputBufferLocked(); derivedThreshold > recoverThreshold {
+		recoverThreshold = derivedThreshold
+	}
+
+	if bufferedDuration <= lowThreshold {
+		if !b.playbackHeadroomLow {
+			b.playbackHeadroomLow = true
+			logAudioEvent(
+				"PlaybackHeadroomLow buffered=%s threshold=%s playerBuffer=%s outputBuffer=%s state=%s",
+				bufferedDuration,
+				lowThreshold,
+				audioDurationForByteCount(int64(b.desiredPlayerBufferSizeLocked())),
+				b.effectiveOutputBufferLocked(),
+				b.stateSummaryLocked(),
+			)
+		}
+		return
+	}
+
+	if b.playbackHeadroomLow && bufferedDuration >= recoverThreshold {
+		b.playbackHeadroomLow = false
+		logAudioEvent(
+			"PlaybackHeadroomRecovered buffered=%s threshold=%s state=%s",
+			bufferedDuration,
+			recoverThreshold,
+			b.stateSummaryLocked(),
+		)
+	}
 }
 
 func (b *AudioBackend) effectivePlayerVolumeLocked() float64 {
@@ -361,11 +493,15 @@ func (b *AudioBackend) ApplyAudioSettings(settings AudioSettings) {
 			b.player.SetVolume(b.effectivePlayerVolumeLocked())
 		}
 	}
+	if b.player != nil {
+		b.player.SetBufferSize(b.desiredPlayerBufferSizeLocked())
+	}
 
 	logAudioEvent(
-		"ApplyAudioSettings device=%q buffer=%s gapless=%t replayGain=%t state=%s",
+		"ApplyAudioSettings device=%q buffer=%s effectiveBuffer=%s gapless=%t replayGain=%t state=%s",
 		b.outputDevice,
 		b.outputBuffer,
+		b.effectiveOutputBufferLocked(),
 		b.gaplessPlayback,
 		b.replayGainEnabled,
 		b.stateSummaryLocked(),
@@ -457,6 +593,7 @@ func (b *AudioBackend) Initialize() error {
 	if b.context != nil {
 		if b.player == nil {
 			b.player = b.context.NewPlayer(&audioPlayerSource{backend: b})
+			b.player.SetBufferSize(b.desiredPlayerBufferSizeLocked())
 			b.player.SetVolume(b.effectivePlayerVolumeLocked())
 			logAudioEvent("Initialize attached player to existing context state=%s", b.stateSummaryLocked())
 		}
@@ -469,7 +606,7 @@ func (b *AudioBackend) Initialize() error {
 		SampleRate:     audioSampleRate,
 		ChannelCount:   audioChannelCount,
 		Format:         oto.FormatSignedInt16LE,
-		BufferSize:     b.outputBuffer,
+		BufferSize:     b.effectiveOutputBufferLocked(),
 		OutputDeviceID: selectedOutputDeviceID,
 	})
 	if err != nil {
@@ -483,8 +620,9 @@ func (b *AudioBackend) Initialize() error {
 
 	b.context = context
 	b.player = context.NewPlayer(&audioPlayerSource{backend: b})
+	b.player.SetBufferSize(b.desiredPlayerBufferSizeLocked())
 	b.player.SetVolume(b.effectivePlayerVolumeLocked())
-	logAudioEvent("Initialize created context device=%q buffer=%s gapless=%t", b.outputDevice, b.outputBuffer, b.gaplessPlayback)
+	logAudioEvent("Initialize created context device=%q buffer=%s effectiveBuffer=%s gapless=%t playerBuffer=%s", b.outputDevice, b.outputBuffer, b.effectiveOutputBufferLocked(), b.gaplessPlayback, audioDurationForByteCount(int64(b.desiredPlayerBufferSizeLocked())))
 	return nil
 }
 
@@ -634,7 +772,10 @@ func (b *AudioBackend) currentPlayedGlobalBytesLocked() int64 {
 		return 0
 	}
 
-	maxReadableGlobalBytes := b.streamDroppedBytes + b.streamReadOffset
+	maxReadableGlobalBytes := b.streamDroppedBytes + b.streamReadOffset - b.playerBufferedBytesLocked()
+	if maxReadableGlobalBytes < b.streamDroppedBytes {
+		maxReadableGlobalBytes = b.streamDroppedBytes
+	}
 	if playedBytes > maxReadableGlobalBytes {
 		playedBytes = maxReadableGlobalBytes
 	}
@@ -765,6 +906,7 @@ func (b *AudioBackend) syncPlaybackLocked() {
 		b.playStarted = time.Time{}
 		b.playbackBaseBytes = 0
 		b.endEventSent = false
+		b.playbackHeadroomLow = false
 		return
 	}
 
@@ -780,6 +922,7 @@ func (b *AudioBackend) syncPlaybackLocked() {
 		if b.playing {
 			b.playing = false
 		}
+		b.playbackHeadroomLow = false
 		if !b.endEventSent {
 			b.endEventID++
 			b.endEventSent = true
@@ -794,6 +937,7 @@ func (b *AudioBackend) syncPlaybackLocked() {
 	}
 
 	b.endEventSent = false
+	b.reportPlaybackHeadroomLocked()
 }
 
 func (b *AudioBackend) snapshotLocked() AudioPlaybackState {
@@ -837,6 +981,7 @@ func (b *AudioBackend) unloadTrackLocked() {
 	b.playStarted = time.Time{}
 	b.playbackBaseBytes = 0
 	b.playing = false
+	b.playbackHeadroomLow = false
 	b.endEventSent = false
 	b.streamCond.Broadcast()
 }

--- a/audio_backend_runtime_test.go
+++ b/audio_backend_runtime_test.go
@@ -27,10 +27,13 @@ func TestOTOAdapters(t *testing.T) {
 	playerPlayed := false
 	playerPaused := false
 	playerVolume := 0.0
+	playerBufferSize := 0
 	playerSeekCalls := 0
 	playerErr := errors.New("player failed")
 	playerAdapter := &otoPlayerAdapter{
 		setVolume: func(volume float64) { playerVolume = volume },
+		setBuffer: func(bufferSize int) { playerBufferSize = bufferSize },
+		buffered:  func() int { return 128 },
 		play:      func() { playerPlayed = true },
 		pause:     func() { playerPaused = true },
 		err:       func() error { return playerErr },
@@ -40,13 +43,14 @@ func TestOTOAdapters(t *testing.T) {
 		},
 	}
 	playerAdapter.SetVolume(0.5)
+	playerAdapter.SetBufferSize(256)
 	playerAdapter.Play()
 	playerAdapter.Pause()
 	if got, err := playerAdapter.Seek(4, io.SeekCurrent); err != nil || got != 5 {
 		t.Fatalf("otoPlayerAdapter.Seek() = (%d, %v), want (5, nil)", got, err)
 	}
-	if !playerPlayed || !playerPaused || playerVolume != 0.5 || playerSeekCalls != 1 || !errors.Is(playerAdapter.Err(), playerErr) {
-		t.Fatalf("otoPlayerAdapter() state = played:%t paused:%t volume:%.2f seeks:%d err:%v", playerPlayed, playerPaused, playerVolume, playerSeekCalls, playerAdapter.Err())
+	if !playerPlayed || !playerPaused || playerVolume != 0.5 || playerBufferSize != 256 || playerAdapter.BufferedSize() != 128 || playerSeekCalls != 1 || !errors.Is(playerAdapter.Err(), playerErr) {
+		t.Fatalf("otoPlayerAdapter() state = played:%t paused:%t volume:%.2f buffer:%d buffered:%d seeks:%d err:%v", playerPlayed, playerPaused, playerVolume, playerBufferSize, playerAdapter.BufferedSize(), playerSeekCalls, playerAdapter.Err())
 	}
 
 	contextClosed := false
@@ -72,6 +76,8 @@ func TestOTOAdapters(t *testing.T) {
 
 type fakeAudioPlayer struct {
 	volume     float64
+	bufferSize int
+	buffered   int
 	playCalls  int
 	pauseCalls int
 	seekCalls  int
@@ -81,6 +87,14 @@ type fakeAudioPlayer struct {
 
 func (p *fakeAudioPlayer) SetVolume(volume float64) {
 	p.volume = volume
+}
+
+func (p *fakeAudioPlayer) SetBufferSize(bufferSize int) {
+	p.bufferSize = bufferSize
+}
+
+func (p *fakeAudioPlayer) BufferedSize() int {
+	return p.buffered
 }
 
 func (p *fakeAudioPlayer) Play() {
@@ -140,6 +154,23 @@ func useFakeAudioContext(t *testing.T, context audioOutputContext, err error) {
 	})
 }
 
+func useFakeAudioContextWithOptionsCapture(t *testing.T, context audioOutputContext, err error, capture func(options *oto.NewContextOptions)) {
+	t.Helper()
+
+	originalNewAudioOutputContext := newAudioOutputContext
+	newAudioOutputContext = func(options *oto.NewContextOptions) (audioOutputContext, <-chan struct{}, error) {
+		if capture != nil {
+			capture(options)
+		}
+		ready := make(chan struct{})
+		close(ready)
+		return context, ready, err
+	}
+	t.Cleanup(func() {
+		newAudioOutputContext = originalNewAudioOutputContext
+	})
+}
+
 func TestAudioBackendInitializeCloseAndOutputDevices(t *testing.T) {
 	originalListAudioOutputDevices := listAudioOutputDevices
 	t.Cleanup(func() {
@@ -166,7 +197,10 @@ func TestAudioBackendInitializeCloseAndOutputDevices(t *testing.T) {
 	}
 
 	fakeContext := &fakeAudioContext{}
-	useFakeAudioContext(t, fakeContext, nil)
+	capturedContextBufferSize := time.Duration(0)
+	useFakeAudioContextWithOptionsCapture(t, fakeContext, nil, func(options *oto.NewContextOptions) {
+		capturedContextBufferSize = options.BufferSize
+	})
 	backend := NewAudioBackend()
 	backend.ffmpegPath = helperPath
 	if err := backend.Initialize(); err != nil {
@@ -174,6 +208,12 @@ func TestAudioBackendInitializeCloseAndOutputDevices(t *testing.T) {
 	}
 	if backend.context == nil || backend.player == nil {
 		t.Fatal("Initialize(success) should populate the audio context and player")
+	}
+	if fakeContext.player.bufferSize != durationToAlignedAudioBytes(defaultAudioPlayerBuffer) {
+		t.Fatalf("Initialize(success) player buffer size = %d, want %d", fakeContext.player.bufferSize, durationToAlignedAudioBytes(defaultAudioPlayerBuffer))
+	}
+	if capturedContextBufferSize != defaultAudioOutputBuffer {
+		t.Fatalf("Initialize(success) context buffer size = %s, want %s", capturedContextBufferSize, defaultAudioOutputBuffer)
 	}
 
 	backendWithExistingContext := NewAudioBackend()
@@ -184,6 +224,9 @@ func TestAudioBackendInitializeCloseAndOutputDevices(t *testing.T) {
 	}
 	if backendWithExistingContext.player == nil {
 		t.Fatal("Initialize(existing context) should attach a player when one is missing")
+	}
+	if fakeContext.player.bufferSize != durationToAlignedAudioBytes(defaultAudioPlayerBuffer) {
+		t.Fatalf("Initialize(existing context) player buffer size = %d, want %d", fakeContext.player.bufferSize, durationToAlignedAudioBytes(defaultAudioPlayerBuffer))
 	}
 
 	failingContext := &fakeAudioContext{err: errors.New("context failed")}
@@ -313,6 +356,16 @@ func TestAudioBackendTransportAndStateHelpers(t *testing.T) {
 	if got := transportBackend.effectivePlayerVolumeLocked(); got != 0 {
 		t.Fatalf("effectivePlayerVolumeLocked(negative volume) = %.2f, want 0", got)
 	}
+	if got, want := transportBackend.effectiveOutputBufferLocked(), defaultAudioOutputBuffer; got != want {
+		t.Fatalf("effectiveOutputBufferLocked(default) = %s, want %s", got, want)
+	}
+	transportBackend.outputBuffer = 900 * time.Millisecond
+	if got, want := transportBackend.effectiveOutputBufferLocked(), 900*time.Millisecond; got != want {
+		t.Fatalf("effectiveOutputBufferLocked(explicit) = %s, want %s", got, want)
+	}
+	if got, want := transportBackend.desiredPlayerBufferSizeLocked(), durationToAlignedAudioBytes(maxAudioPlayerBuffer); got != want {
+		t.Fatalf("desiredPlayerBufferSizeLocked(cap) = %d, want %d", got, want)
+	}
 
 	seekBackend := NewAudioBackend()
 	if err := seekBackend.seekLocked(1); err == nil {
@@ -425,6 +478,40 @@ func TestAudioBackendStateHelperEdgeCases(t *testing.T) {
 	state := snapshotBackend.snapshotLocked()
 	if state.CurrentTime != state.Duration || state.Duration != 1 {
 		t.Fatalf("snapshotLocked(clamped) = %#v, want clamped currentTime=duration=1", state)
+	}
+}
+
+func TestCurrentPlayedGlobalBytesSubtractsPlayerBufferedBytes(t *testing.T) {
+	backend := NewAudioBackend()
+	backend.streamSegments = []audioTrackSegment{{SourcePath: "track.flac", PCMData: make([]byte, 3*audioBytesPerSecond)}}
+	backend.player = &fakeAudioPlayer{buffered: audioBytesPerSecond}
+	backend.streamReadOffset = int64(3 * audioBytesPerSecond)
+	backend.playbackBaseBytes = int64(3 * audioBytesPerSecond)
+
+	if got, want := backend.currentPlayedGlobalBytesLocked(), int64(2*audioBytesPerSecond); got != want {
+		t.Fatalf("currentPlayedGlobalBytesLocked(buffered clamp) = %d, want %d", got, want)
+	}
+}
+
+func TestSyncPlaybackLockedDoesNotEndWhilePlayerStillBuffered(t *testing.T) {
+	backend := NewAudioBackend()
+	backend.streamSegments = []audioTrackSegment{{SourcePath: "track.flac", PCMData: make([]byte, 2*audioBytesPerSecond)}}
+	backend.player = &fakeAudioPlayer{buffered: audioBytesPerSecond}
+	backend.streamReadOffset = int64(2 * audioBytesPerSecond)
+	backend.playbackBaseBytes = int64(2 * audioBytesPerSecond)
+	backend.playing = true
+	backend.playStarted = time.Now().Add(-2 * time.Second)
+
+	backend.syncPlaybackLocked()
+
+	if !backend.playing {
+		t.Fatal("syncPlaybackLocked() should keep playing while buffered audio remains queued")
+	}
+	if backend.endEventID != 0 {
+		t.Fatalf("syncPlaybackLocked() endEventID = %d, want 0 while buffered audio remains", backend.endEventID)
+	}
+	if got, want := backend.playbackBaseBytes, int64(audioBytesPerSecond); got != want {
+		t.Fatalf("syncPlaybackLocked() playbackBaseBytes = %d, want %d", got, want)
 	}
 }
 

--- a/frontend/src/controllers/library-controller.test.ts
+++ b/frontend/src/controllers/library-controller.test.ts
@@ -463,6 +463,64 @@ describe('createLibraryController', () => {
         expect(readImageThumbnail.mock.calls.length).toBeLessThan(tracks.length);
     });
 
+    it('limits concurrent album thumbnail loads while browsing album view', async () => {
+        const tracks = Array.from({ length: 40 }, (_, index) => createTrack({
+            title: `Track ${index}`,
+            name: `Track ${index}`,
+            path: `/music/library/artist-${index}/album-${index}/01 Track.flac`,
+            relativePath: `Library/Artist ${index}/Album ${index}/01 Track.flac`,
+            folderPath: `Library/Artist ${index}/Album ${index}`,
+            displayAlbum: `Album ${index}`,
+            displayArtist: `Artist ${index}`,
+        }));
+        let activeThumbnailLoads = 0;
+        let maxConcurrentThumbnailLoads = 0;
+        const pendingThumbnailResolvers: Array<() => void> = [];
+        const readImageThumbnail = vi.fn(async (_path: string, _maxEdge: number) => {
+            activeThumbnailLoads += 1;
+            maxConcurrentThumbnailLoads = Math.max(maxConcurrentThumbnailLoads, activeThumbnailLoads);
+
+            await new Promise<void>((resolve) => {
+                pendingThumbnailResolvers.push(() => {
+                    activeThumbnailLoads -= 1;
+                    resolve();
+                });
+            });
+
+            return {
+                base64: 'thumb',
+                mimeType: 'image/jpeg',
+            };
+        });
+        const { controller } = mountLibraryController({
+            tracks,
+            readImageThumbnail,
+            getFolderCoverPath: (folderPath: string) => `/covers/${folderPath.replace(/\s+/g, '-').toLowerCase()}.jpg`,
+        });
+
+        controller.setLibraryRootName('Library');
+        controller.setSidebarAutoFolderPath('Library/Artist 0');
+        controller.setSidebarOpen(true);
+        await flushPromises();
+
+        controller.setSidebarExpanded(true);
+        await flushPromises();
+
+        await waitForCondition(() => {
+            expect(readImageThumbnail).toHaveBeenCalledTimes(4);
+        });
+
+        expect(maxConcurrentThumbnailLoads).toBe(4);
+
+        while (pendingThumbnailResolvers.length > 0) {
+            const resolvers = pendingThumbnailResolvers.splice(0, pendingThumbnailResolvers.length);
+            resolvers.forEach((resolve) => {
+                resolve();
+            });
+            await flushPromises();
+        }
+    });
+
     it('reuses overlapping album card elements when the virtualized window shifts', async () => {
         vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function(this: HTMLElement) {
             if (this.classList.contains('library-album-grid-pane')) {
@@ -722,7 +780,7 @@ describe('createLibraryController', () => {
         });
     });
 
-    it('evicts older album thumbnails after scrolling past the cache limit', async () => {
+    it('restores the first album cover after scrolling away and back again', async () => {
         vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function(this: HTMLElement) {
             if (this.classList.contains('library-album-grid-pane')) {
                 return 240;
@@ -801,7 +859,9 @@ describe('createLibraryController', () => {
         await flushPromises();
 
         await waitForCondition(() => {
-            expect(countCallsForCoverPath(firstCoverPath)).toBeGreaterThan(1);
+            const firstAlbumImage = libraryBrowser.querySelector('[data-folder-path="Library/Artist 0/Album 0"] .library-album-cover-image') as HTMLImageElement | null;
+            expect(firstAlbumImage?.dataset.coverLoaded).toBe('true');
+            expect(firstAlbumImage?.getAttribute('src')).toBe('data:image/jpeg;base64,thumb');
         });
     });
 

--- a/frontend/src/controllers/library-controller.ts
+++ b/frontend/src/controllers/library-controller.ts
@@ -70,10 +70,20 @@ const albumGridMinColumnWidthPx = 75;
 const albumGridOverscanRows = 3;
 const albumGridInitialThumbnailBatchSize = 12;
 const albumGridCoverResolutionBatchSize = 24;
-const albumGridMinimumThumbnailCacheSize = 96;
+const albumGridThumbnailLoadConcurrency = 4;
+const albumGridMinimumThumbnailCacheSize = 32;
 const albumGridThumbnailCacheWindowMultiplier = 2;
 const unknownAlbumLabel = 'Unknown Album';
 const unknownArtistLabel = 'Unknown Artist';
+
+type RecursiveAlbumCoverCandidate = {
+    path: string;
+    descendantDistance: number;
+    priority: number;
+    sortKey: string;
+};
+
+type AlbumThumbnailLoadPriority = 'eager' | 'normal';
 
 export const createLibraryController = (options: LibraryControllerOptions) => {
     const {
@@ -104,7 +114,11 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
     let albumGridRenderVersion = 0;
     let cachedAlbumGridEntries: AlbumGridEntry[] | null = null;
     let cachedAlbumGridEntriesPromise: Promise<AlbumGridEntry[]> | null = null;
+    let indexedRecursiveAlbumCoverPathByFolder: Map<string, string> | null = null;
     let albumGridThumbnailCacheLimit = albumGridMinimumThumbnailCacheSize;
+    let albumThumbnailLoadsInFlight = 0;
+    const eagerAlbumThumbnailLoadWaiters: Array<() => void> = [];
+    const normalAlbumThumbnailLoadWaiters: Array<() => void> = [];
     const resolvedAlbumCoverPathByFolder = new Map<string, string>();
     const paneStateByElement = new WeakMap<HTMLUListElement, PaneState>();
     const albumThumbnailDataUrlByCoverPath = new Map<string, string | null>();
@@ -221,10 +235,80 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
         }
     };
 
-    const folderDepth = (path: string): number => path.split('/').filter((segment) => segment.trim() !== '').length;
+    const normalizedFolderKey = (path: string): string => path.trim().toLowerCase();
+
+    const folderPathSegments = (path: string): string[] => {
+        return path
+            .split('/')
+            .map((segment) => segment.trim())
+            .filter((segment) => segment !== '');
+    };
+
+    const shouldReplaceRecursiveAlbumCoverCandidate = (
+        nextCandidate: RecursiveAlbumCoverCandidate,
+        existingCandidate?: RecursiveAlbumCoverCandidate,
+    ): boolean => {
+        if (!existingCandidate) {
+            return true;
+        }
+        if (nextCandidate.descendantDistance !== existingCandidate.descendantDistance) {
+            return nextCandidate.descendantDistance < existingCandidate.descendantDistance;
+        }
+        if (nextCandidate.priority !== existingCandidate.priority) {
+            return nextCandidate.priority < existingCandidate.priority;
+        }
+
+        return naturalOrderCollator.compare(nextCandidate.sortKey, existingCandidate.sortKey) < 0;
+    };
+
+    const recursiveAlbumCoverPathIndex = (): Map<string, string> => {
+        if (indexedRecursiveAlbumCoverPathByFolder) {
+            return indexedRecursiveAlbumCoverPathByFolder;
+        }
+
+        const bestCoverCandidateByFolder = new Map<string, RecursiveAlbumCoverCandidate>();
+        for (const imageFile of options.getImageFiles()) {
+            if (!isPreferredAlbumCoverImagePath(imageFile.path || imageFile.name || '')) {
+                continue;
+            }
+
+            const imageFolderSegments = folderPathSegments(imageFile.folderPath || '');
+            if (imageFolderSegments.length === 0) {
+                continue;
+            }
+
+            const candidatePath = (imageFile.path || '').trim();
+            if (candidatePath === '') {
+                continue;
+            }
+
+            const priority = albumCoverPriority(imageFile.name || '');
+            const sortKey = imageFile.relativePath || imageFile.path || imageFile.name || candidatePath;
+            for (let ancestorLength = 1; ancestorLength <= imageFolderSegments.length; ancestorLength += 1) {
+                const ancestorFolderPath = imageFolderSegments.slice(0, ancestorLength).join('/');
+                const ancestorFolderKey = normalizedFolderKey(ancestorFolderPath);
+                const nextCandidate: RecursiveAlbumCoverCandidate = {
+                    path: candidatePath,
+                    descendantDistance: imageFolderSegments.length - ancestorLength,
+                    priority,
+                    sortKey,
+                };
+                const existingCandidate = bestCoverCandidateByFolder.get(ancestorFolderKey);
+                if (shouldReplaceRecursiveAlbumCoverCandidate(nextCandidate, existingCandidate)) {
+                    bestCoverCandidateByFolder.set(ancestorFolderKey, nextCandidate);
+                }
+            }
+        }
+
+        indexedRecursiveAlbumCoverPathByFolder = new Map(
+            Array.from(bestCoverCandidateByFolder.entries()).map(([folderKey, candidate]) => [folderKey, candidate.path]),
+        );
+
+        return indexedRecursiveAlbumCoverPathByFolder;
+    };
 
     const resolveAlbumCoverPath = (albumFolderPath: string, candidateFolders: string[]): string => {
-        const cacheKey = albumFolderPath.trim().toLowerCase();
+        const cacheKey = normalizedFolderKey(albumFolderPath);
         const cachedCoverPath = resolvedAlbumCoverPathByFolder.get(cacheKey);
         if (cachedCoverPath !== undefined) {
             return cachedCoverPath;
@@ -239,26 +323,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
         }
 
         if (cacheKey !== '') {
-            const recursiveCoverPath = options.getImageFiles()
-                .filter((imageFile) => {
-                    const imageFolderPath = (imageFile.folderPath || '').trim().toLowerCase();
-                    return imageFolderPath === cacheKey || imageFolderPath.startsWith(`${cacheKey}/`);
-                })
-                .filter((imageFile) => isPreferredAlbumCoverImagePath(imageFile.path || imageFile.name || ''))
-                .sort((left, right) => {
-                    const depthComparison = folderDepth(left.folderPath || '') - folderDepth(right.folderPath || '');
-                    if (depthComparison !== 0) {
-                        return depthComparison;
-                    }
-
-                    const priorityComparison = albumCoverPriority(left.name || '') - albumCoverPriority(right.name || '');
-                    if (priorityComparison !== 0) {
-                        return priorityComparison;
-                    }
-
-                    return naturalOrderCollator.compare(left.relativePath || left.path || left.name, right.relativePath || right.path || right.name);
-                })[0]?.path || '';
-
+            const recursiveCoverPath = recursiveAlbumCoverPathIndex().get(cacheKey) || '';
             resolvedAlbumCoverPathByFolder.set(cacheKey, recursiveCoverPath);
             return recursiveCoverPath;
         }
@@ -275,9 +340,36 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
         });
     };
 
+    const acquireAlbumThumbnailLoadSlot = async (priority: AlbumThumbnailLoadPriority): Promise<void> => {
+        while (albumThumbnailLoadsInFlight >= albumGridThumbnailLoadConcurrency) {
+            await new Promise<void>((resolve) => {
+                if (priority === 'eager') {
+                    eagerAlbumThumbnailLoadWaiters.push(resolve);
+                    return;
+                }
+
+                normalAlbumThumbnailLoadWaiters.push(resolve);
+            });
+        }
+
+        albumThumbnailLoadsInFlight += 1;
+    };
+
+    const releaseAlbumThumbnailLoadSlot = (): void => {
+        if (albumThumbnailLoadsInFlight > 0) {
+            albumThumbnailLoadsInFlight -= 1;
+        }
+
+        const nextWaiter = eagerAlbumThumbnailLoadWaiters.shift() ?? normalAlbumThumbnailLoadWaiters.shift();
+        if (nextWaiter) {
+            nextWaiter();
+        }
+    };
+
     const invalidateAlbumGridCache = (): void => {
         cachedAlbumGridEntries = null;
         cachedAlbumGridEntriesPromise = null;
+        indexedRecursiveAlbumCoverPathByFolder = null;
         resolvedAlbumCoverPathByFolder.clear();
         albumGridRenderVersion += 1;
     };
@@ -436,7 +528,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
         return cachedDataUrl;
     };
 
-    const loadAlbumThumbnailDataUrl = async (coverPath: string): Promise<string | null> => {
+    const loadAlbumThumbnailDataUrl = async (coverPath: string, priority: AlbumThumbnailLoadPriority = 'normal'): Promise<string | null> => {
         const cachedDataUrl = getCachedAlbumThumbnailDataUrl(coverPath);
         if (cachedDataUrl !== undefined) {
             return cachedDataUrl;
@@ -447,8 +539,10 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
             return await pendingLoad;
         }
 
-        const loadPromise = options.readImageThumbnail(coverPath, albumCoverThumbnailMaxEdgePx)
-            .then((thumbnail) => {
+        const loadPromise = (async () => {
+            await acquireAlbumThumbnailLoadSlot(priority);
+            try {
+                const thumbnail = await options.readImageThumbnail(coverPath, albumCoverThumbnailMaxEdgePx);
                 const base64 = (thumbnail.base64 || '').trim();
                 if (base64 === '') {
                     touchAlbumThumbnailCacheEntry(coverPath, null);
@@ -463,15 +557,15 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
                 touchAlbumThumbnailCacheEntry(coverPath, dataUrl);
                 pruneAlbumThumbnailCache();
                 return dataUrl;
-            })
-            .catch(() => {
+            } catch {
                 touchAlbumThumbnailCacheEntry(coverPath, null);
                 pruneAlbumThumbnailCache();
                 return null;
-            })
-            .finally(() => {
+            } finally {
+                releaseAlbumThumbnailLoadSlot();
                 albumThumbnailLoadPromiseByCoverPath.delete(coverPath);
-            });
+            }
+        })();
 
         albumThumbnailLoadPromiseByCoverPath.set(coverPath, loadPromise);
         return await loadPromise;
@@ -493,7 +587,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
         });
     };
 
-    const hydrateAlbumCoverImage = async (image: HTMLImageElement): Promise<void> => {
+    const hydrateAlbumCoverImage = async (image: HTMLImageElement, priority: AlbumThumbnailLoadPriority = 'normal'): Promise<void> => {
         const coverPath = (image.dataset.coverPath || '').trim();
         if (coverPath === '' || image.dataset.coverLoaded === 'true') {
             return;
@@ -501,7 +595,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
 
         image.dataset.coverLoaded = 'true';
         const coverElement = image.closest('.library-album-cover');
-        const dataUrl = await loadAlbumThumbnailDataUrl(coverPath);
+        const dataUrl = await loadAlbumThumbnailDataUrl(coverPath, priority);
         if (!(coverElement instanceof HTMLElement) || !image.isConnected) {
             return;
         }
@@ -518,7 +612,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
 
     const hydrateAlbumGridThumbnailBatch = async (images: HTMLImageElement[]): Promise<void> => {
         await Promise.all(images.map(async (image) => {
-            await hydrateAlbumCoverImage(image);
+            await hydrateAlbumCoverImage(image, 'eager');
         }));
     };
 
@@ -642,6 +736,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
     };
 
     const disposeAlbumGridCard = (cardElements: AlbumGridCardElements): void => {
+        const coverPath = (cardElements.image.dataset.coverPath || '').trim();
         albumGridThumbnailObserver?.unobserve(cardElements.image);
         cardElements.image.removeAttribute('src');
         delete cardElements.image.dataset.coverPath;
@@ -649,6 +744,10 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
         cardElements.cover.classList.remove('has-image');
         cardElements.cover.classList.remove('is-unavailable');
         cardElements.cover.classList.add('is-loading');
+        if (coverPath !== '') {
+            albumThumbnailDataUrlByCoverPath.delete(coverPath);
+            albumThumbnailLoadPromiseByCoverPath.delete(coverPath);
+        }
     };
 
     const renderExpandedAlbumGrid = (direction: RenderDirection): void => {
@@ -800,10 +899,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
                 }
 
                 if (eagerThumbnailImages.length > 0) {
-                    await hydrateAlbumGridThumbnailBatch(eagerThumbnailImages);
-                    if (!isAlbumGridRenderCurrent(renderVersion, pane)) {
-                        return;
-                    }
+                    void hydrateAlbumGridThumbnailBatch(eagerThumbnailImages);
                 }
 
                 const queuedImages = Array.from(grid.querySelectorAll('.library-album-cover-image[data-cover-path]')) as HTMLImageElement[];
@@ -826,6 +922,13 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
                 });
             };
 
+            const handlePaneScroll = (): void => {
+                updateAlbumGridPaneEdgeFade();
+                scheduleVirtualizedAlbumRender();
+            };
+
+            pane.addEventListener('scroll', handlePaneScroll, { passive: true });
+
             if (!isAlbumGridRenderCurrent(renderVersion, pane)) {
                 return;
             }
@@ -835,7 +938,6 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
                 return;
             }
 
-            pane.addEventListener('scroll', scheduleVirtualizedAlbumRender, { passive: true });
             albumGridWindowResizeListener = () => {
                 scheduleVirtualizedAlbumRender();
             };


### PR DESCRIPTION
Use a safer effective default output buffer and a larger Oto player prebuffer when the configured buffer is unset or too small. Track buffered bytes and log low-headroom recovery events so load-test runs can be diagnosed from backend logs.

Separately, make a few adjustments to how thumbnails in album view are fetched and rendered to minimize the chance of dropouts during playback.