### PR TITLE
Prevent duplicate playlist additions

### DIFF
--- a/frontend/src/app-controller-setup.ts
+++ b/frontend/src/app-controller-setup.ts
@@ -145,6 +145,7 @@ export const setupAppControllers = (context: AppControllerSetupContext) => {
         },
         savePlaylistData: (playlistPath: string, trackPaths: string[]) => context.savePlaylistData(playlistPath, trackPaths),
         appendTracksToPlaylistData: (playlistPath: string, trackPaths: string[]) => context.appendTracksToPlaylistData(playlistPath, trackPaths),
+        openErrorModal: context.openErrorModal,
         getFavoritePlaylists: () => context.currentSettings.favoritePlaylists,
         hasListenHistoryPlaylist: () => (
             context.currentSettings.localLibraryFilesDatabaseEnabled

--- a/frontend/src/app-queue-menu-runtime.test.ts
+++ b/frontend/src/app-queue-menu-runtime.test.ts
@@ -53,3 +53,86 @@ describe('createAppQueueMenuRuntime openCurrentTrackFolderInSidebar', () => {
         expect(libraryController.navigateToFolder).toHaveBeenCalledWith('Library/Artist/Album');
     });
 });
+
+describe('createAppQueueMenuRuntime addSidebarSelectionToPlaylist', () => {
+    it('shows an error and blocks append when duplicate prevention is enabled for the current track', async () => {
+        const appendTracksToPlaylist = vi.fn(async () => true);
+        const openErrorModal = vi.fn();
+        const prompt = vi.fn(async () => ({
+            selectedPath: '/playlists/demo.m3u8',
+            duplicatePreventionEnabled: true,
+        }));
+
+        const context = {
+            currentTrackIndex: 0,
+            tracks: [
+                { path: '/music/track-0.flac', folderPath: '/music' },
+                { path: '/music/track-1.flac', folderPath: '/music' },
+            ],
+            playlistTargetModalController: { prompt },
+            playlistController: {
+                getAvailablePlaylistTargets: vi.fn(() => [{ path: '/playlists/demo.m3u8', label: 'demo.m3u8' }]),
+                openPlaylistTarget: vi.fn(async () => null),
+                createPlaylistTarget: vi.fn(async () => null),
+                isTrackAlreadyInLoadedPlaylist: vi.fn(() => true),
+                appendTracksToPlaylist,
+            },
+            openErrorModal,
+        } as unknown as Parameters<typeof createAppQueueMenuRuntime>[0];
+
+        const runtime = createAppQueueMenuRuntime(context);
+
+        await runtime.addSidebarSelectionToPlaylist({
+            trackIndexes: [0],
+            folderPath: '',
+            folderLabel: '',
+            folderTarget: false,
+            trackIndexesScopedToSelection: true,
+        });
+
+        expect(openErrorModal).toHaveBeenCalledWith(
+            'Track already in playlist',
+            'The current track is already in the active playlist. Disable duplicate prevention to add it again.',
+        );
+        expect(appendTracksToPlaylist).not.toHaveBeenCalled();
+    });
+
+    it('allows append when duplicate prevention is disabled', async () => {
+        const appendTracksToPlaylist = vi.fn(async () => true);
+        const openErrorModal = vi.fn();
+        const prompt = vi.fn(async () => ({
+            selectedPath: '/playlists/demo.m3u8',
+            duplicatePreventionEnabled: false,
+        }));
+
+        const context = {
+            currentTrackIndex: 0,
+            tracks: [
+                { path: '/music/track-0.flac', folderPath: '/music' },
+                { path: '/music/track-1.flac', folderPath: '/music' },
+            ],
+            playlistTargetModalController: { prompt },
+            playlistController: {
+                getAvailablePlaylistTargets: vi.fn(() => [{ path: '/playlists/demo.m3u8', label: 'demo.m3u8' }]),
+                openPlaylistTarget: vi.fn(async () => null),
+                createPlaylistTarget: vi.fn(async () => null),
+                isTrackAlreadyInLoadedPlaylist: vi.fn(() => true),
+                appendTracksToPlaylist,
+            },
+            openErrorModal,
+        } as unknown as Parameters<typeof createAppQueueMenuRuntime>[0];
+
+        const runtime = createAppQueueMenuRuntime(context);
+
+        await runtime.addSidebarSelectionToPlaylist({
+            trackIndexes: [0],
+            folderPath: '',
+            folderLabel: '',
+            folderTarget: false,
+            trackIndexesScopedToSelection: true,
+        });
+
+        expect(appendTracksToPlaylist).toHaveBeenCalledWith('/playlists/demo.m3u8', [0]);
+        expect(openErrorModal).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/app-queue-menu-runtime.ts
+++ b/frontend/src/app-queue-menu-runtime.ts
@@ -297,12 +297,25 @@ export const createAppQueueMenuRuntime = (context: AppQueueMenuRuntimeContext) =
             onOpenPlaylist: () => context.playlistController.openPlaylistTarget(),
             onCreatePlaylist: () => context.playlistController.createPlaylistTarget(),
             emptyStateMessage: 'No playlists are available yet. Open one or create one below.',
+            duplicatePreventionLabel: 'Block duplicate current track in active playlist',
         });
         if (!playlistPath) {
             return;
         }
 
-        const appended = await context.playlistController.appendTracksToPlaylist(playlistPath, trackIndexes);
+        if (
+            playlistPath.duplicatePreventionEnabled
+            && trackIndexes.includes(context.currentTrackIndex)
+            && context.playlistController.isTrackAlreadyInLoadedPlaylist(playlistPath.selectedPath, context.currentTrackIndex)
+        ) {
+            context.openErrorModal(
+                'Track already in playlist',
+                'The current track is already in the active playlist. Disable duplicate prevention to add it again.',
+            );
+            return;
+        }
+
+        const appended = await context.playlistController.appendTracksToPlaylist(playlistPath.selectedPath, trackIndexes);
         if (!appended) {
             context.openErrorModal('Add to playlist failed', 'Silphium could not append the selected items to that playlist.');
         }

--- a/frontend/src/components/overlays/overlays.css
+++ b/frontend/src/components/overlays/overlays.css
@@ -2645,6 +2645,33 @@
     display: none;
 }
 
+.playlist-target-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: fit-content;
+    max-width: 100%;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 0.8rem;
+    line-height: 1.3;
+    cursor: pointer;
+}
+
+.playlist-target-toggle[hidden] {
+    display: none;
+}
+
+.playlist-target-toggle-input {
+    inline-size: 0.95rem;
+    block-size: 0.95rem;
+    margin: 0;
+    accent-color: rgba(255, 255, 255, 0.85);
+}
+
+.playlist-target-toggle-label {
+    opacity: 0.88;
+}
+
 .playlist-target-tools {
     display: flex;
     justify-content: flex-end;
@@ -2856,8 +2883,12 @@
     top: calc(100% + 0.35rem);
     left: 0;
     right: 0;
+    max-height: 6.25rem;
+    overflow-y: auto;
+    overscroll-behavior: contain;
     padding: 0.35rem;
     display: grid;
+    align-content: start;
     gap: 0.18rem;
     border: 1px solid rgba(255, 255, 255, 0.16);
     border-radius: 0.6rem;
@@ -2865,6 +2896,11 @@
     backdrop-filter: blur(10px);
     box-shadow: 0 0.8rem 2.2rem rgba(0, 0, 0, 0.38);
     z-index: 2;
+}
+
+.playlist-source-wrap.opens-upward .playlist-source-menu {
+    top: auto;
+    bottom: calc(100% + 0.35rem);
 }
 
 .playlist-source-menu[hidden] {
@@ -3000,6 +3036,29 @@
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
+}
+
+.playlist-duplicate-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-left: 0.2rem;
+    font-size: 0.76rem;
+    line-height: 1.2;
+    color: rgba(255, 255, 255, 0.9);
+    cursor: pointer;
+    user-select: none;
+}
+
+.playlist-duplicate-toggle-input {
+    inline-size: 0.9rem;
+    block-size: 0.9rem;
+    margin: 0;
+    accent-color: rgba(255, 255, 255, 0.85);
+}
+
+.playlist-duplicate-toggle-label {
+    opacity: 0.88;
 }
 
 .playlist-action-btn {

--- a/frontend/src/components/overlays/playlist-modal.ts
+++ b/frontend/src/components/overlays/playlist-modal.ts
@@ -13,6 +13,8 @@ export type PlaylistModalElements = {
     playlistHydrationProgress: HTMLParagraphElement;
     playlistHydrationCount: HTMLSpanElement;
     playlistList: HTMLUListElement;
+    playlistPreventDuplicateWrap: HTMLLabelElement;
+    playlistPreventDuplicateCheckbox: HTMLInputElement;
     playlistOpen: HTMLButtonElement;
     playlistCreate: HTMLButtonElement;
     playlistAddCurrent: HTMLButtonElement;
@@ -46,6 +48,10 @@ export const renderPlaylistModal = (): string => `
             <footer class="playlist-actions">
                 <div class="playlist-actions-left">
                     <button id="playlist-add-current" class="playlist-action-btn" type="button" title="Add track to current playlist" aria-label="Add track to current playlist"><svg class="playlist-action-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M10.75 4.75C10.75 4.06 11.31 3.5 12 3.5C12.69 3.5 13.25 4.06 13.25 4.75V10.75H19.25C19.94 10.75 20.5 11.31 20.5 12C20.5 12.69 19.94 13.25 19.25 13.25H13.25V19.25C13.25 19.94 12.69 20.5 12 20.5C11.31 20.5 10.75 19.94 10.75 19.25V13.25H4.75C4.06 13.25 3.5 12.69 3.5 12C3.5 11.31 4.06 10.75 4.75 10.75H10.75V4.75Z"/></svg></button>
+                    <label id="playlist-prevent-duplicate-wrap" class="playlist-duplicate-toggle" title="Block adding the current track when it is already present in the active playlist">
+                        <input id="playlist-prevent-duplicate" class="playlist-duplicate-toggle-input" type="checkbox" aria-label="Prevent duplicate current track">
+                        <span class="playlist-duplicate-toggle-label">Prevent duplicates</span>
+                    </label>
                 </div>
                 <div class="playlist-actions-right">
                     <button id="playlist-create" class="playlist-action-btn" type="button" title="Create new playlist" aria-label="Create new playlist"><svg class="playlist-action-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M6 3.5C4.9 3.5 4 4.4 4 5.5V18.5C4 19.6 4.9 20.5 6 20.5H18C19.1 20.5 20 19.6 20 18.5V9L14.5 3.5H6ZM14 5.6L17.9 9.5H14V5.6ZM7.5 11H16.5V12.5H7.5V11ZM7.5 14H16.5V15.5H7.5V14Z"/></svg></button>
@@ -72,6 +78,8 @@ export const getPlaylistModalElements = (root: ParentNode): PlaylistModalElement
     playlistHydrationProgress: root.querySelector('#playlist-hydration-progress') as HTMLParagraphElement,
     playlistHydrationCount: root.querySelector('#playlist-hydration-count') as HTMLSpanElement,
     playlistList: root.querySelector('#playlist-list') as HTMLUListElement,
+    playlistPreventDuplicateWrap: root.querySelector('#playlist-prevent-duplicate-wrap') as HTMLLabelElement,
+    playlistPreventDuplicateCheckbox: root.querySelector('#playlist-prevent-duplicate') as HTMLInputElement,
     playlistOpen: root.querySelector('#playlist-open') as HTMLButtonElement,
     playlistCreate: root.querySelector('#playlist-create') as HTMLButtonElement,
     playlistAddCurrent: root.querySelector('#playlist-add-current') as HTMLButtonElement,

--- a/frontend/src/components/overlays/playlist-target-modal.ts
+++ b/frontend/src/components/overlays/playlist-target-modal.ts
@@ -5,6 +5,8 @@ export type PlaylistTargetModalElements = {
     playlistTargetTitle: HTMLParagraphElement;
     playlistTargetMessage: HTMLParagraphElement;
     playlistTargetSelect: HTMLSelectElement;
+    playlistTargetDuplicateWrap: HTMLLabelElement;
+    playlistTargetDuplicateCheckbox: HTMLInputElement;
     playlistTargetHint: HTMLParagraphElement;
     playlistTargetOpen: HTMLButtonElement;
     playlistTargetCreate: HTMLButtonElement;
@@ -25,6 +27,10 @@ export const renderPlaylistTargetModal = (): string => `
                 <label class="playlist-target-field" for="playlist-target-select">
                     <span class="playlist-target-field-label">Playlist</span>
                     <select id="playlist-target-select" class="playlist-target-select" aria-label="Choose playlist"></select>
+                </label>
+                <label id="playlist-target-duplicate-wrap" class="playlist-target-toggle" hidden>
+                    <input id="playlist-target-duplicate" class="playlist-target-toggle-input" type="checkbox">
+                    <span id="playlist-target-duplicate-label" class="playlist-target-toggle-label">Prevent duplicate tracks</span>
                 </label>
                 <p id="playlist-target-hint" class="playlist-target-hint" hidden></p>
                 <div class="playlist-target-tools">
@@ -47,6 +53,8 @@ export const getPlaylistTargetModalElements = (root: ParentNode): PlaylistTarget
     playlistTargetTitle: root.querySelector('#playlist-target-title') as HTMLParagraphElement,
     playlistTargetMessage: root.querySelector('#playlist-target-message') as HTMLParagraphElement,
     playlistTargetSelect: root.querySelector('#playlist-target-select') as HTMLSelectElement,
+    playlistTargetDuplicateWrap: root.querySelector('#playlist-target-duplicate-wrap') as HTMLLabelElement,
+    playlistTargetDuplicateCheckbox: root.querySelector('#playlist-target-duplicate') as HTMLInputElement,
     playlistTargetHint: root.querySelector('#playlist-target-hint') as HTMLParagraphElement,
     playlistTargetOpen: root.querySelector('#playlist-target-open') as HTMLButtonElement,
     playlistTargetCreate: root.querySelector('#playlist-target-create') as HTMLButtonElement,

--- a/frontend/src/controllers/playlist-controller.test.ts
+++ b/frontend/src/controllers/playlist-controller.test.ts
@@ -73,6 +73,7 @@ const mountPlaylistController = (options: { state?: PlaylistControllerState } = 
     const ensureTrackTagsResolvedBatch = vi.fn(async () => undefined);
     const savePlaylistTrackMetadataCache = vi.fn(async () => true);
     const savePlaylistData = vi.fn(async () => true);
+    const openErrorModal = vi.fn();
 
     const controller = createPlaylistController({
         trigger,
@@ -96,6 +97,7 @@ const mountPlaylistController = (options: { state?: PlaylistControllerState } = 
         savePlaylistTrackMetadataCache,
         savePlaylistData,
         appendTracksToPlaylistData,
+        openErrorModal,
         getFavoritePlaylists: () => favoritePlaylists,
         hasListenHistoryPlaylist: () => listenHistoryEnabled,
         onTrackChosen,
@@ -110,6 +112,7 @@ const mountPlaylistController = (options: { state?: PlaylistControllerState } = 
         loadListenHistoryData,
         loadPlaylistData,
         onTrackChosen,
+        openErrorModal,
         savePlaylistTrackMetadataCache,
         savePlaylistData,
         setListenHistoryEnabled: (enabled: boolean) => {
@@ -219,6 +222,7 @@ describe('createPlaylistController', () => {
             savePlaylistTrackMetadataCache: vi.fn(async () => true),
             savePlaylistData: vi.fn(async () => true),
             appendTracksToPlaylistData: vi.fn(async () => true),
+            openErrorModal: vi.fn(),
             getFavoritePlaylists: () => [],
             hasListenHistoryPlaylist: () => false,
             onTrackChosen,
@@ -276,6 +280,7 @@ describe('createPlaylistController', () => {
             savePlaylistTrackMetadataCache: vi.fn(async () => true),
             savePlaylistData: vi.fn(async () => true),
             appendTracksToPlaylistData: vi.fn(async () => true),
+            openErrorModal: vi.fn(),
             getFavoritePlaylists: () => [],
             hasListenHistoryPlaylist: () => false,
             onTrackChosen: vi.fn(async (trackIndex: number) => {
@@ -372,6 +377,72 @@ describe('createPlaylistController', () => {
         expect(favoriteOption?.classList.contains('is-empty')).toBe(true);
     });
 
+    it('constrains the source menu to the dialog and opens it upward when space below is limited', () => {
+        const { controller, elements } = mountPlaylistController();
+
+        vi.spyOn(elements.playlistDialog, 'getBoundingClientRect').mockReturnValue({
+            x: 0,
+            y: 0,
+            top: 100,
+            right: 700,
+            bottom: 260,
+            left: 100,
+            width: 600,
+            height: 160,
+            toJSON: () => ({}),
+        });
+        vi.spyOn(elements.playlistSourceWrap, 'getBoundingClientRect').mockReturnValue({
+            x: 0,
+            y: 0,
+            top: 180,
+            right: 500,
+            bottom: 212,
+            left: 180,
+            width: 320,
+            height: 32,
+            toJSON: () => ({}),
+        });
+
+        controller.openModal();
+        elements.playlistSourceButton.click();
+
+        expect(elements.playlistSourceWrap.classList.contains('opens-upward')).toBe(true);
+        expect(elements.playlistSourceMenu.style.maxHeight).toBe('72px');
+    });
+
+    it('caps the source menu height to roughly three visible items even when more space is available', () => {
+        const { controller, elements } = mountPlaylistController();
+
+        vi.spyOn(elements.playlistDialog, 'getBoundingClientRect').mockReturnValue({
+            x: 0,
+            y: 0,
+            top: 100,
+            right: 700,
+            bottom: 520,
+            left: 100,
+            width: 600,
+            height: 420,
+            toJSON: () => ({}),
+        });
+        vi.spyOn(elements.playlistSourceWrap, 'getBoundingClientRect').mockReturnValue({
+            x: 0,
+            y: 0,
+            top: 140,
+            right: 500,
+            bottom: 172,
+            left: 180,
+            width: 320,
+            height: 32,
+            toJSON: () => ({}),
+        });
+
+        controller.openModal();
+        elements.playlistSourceButton.click();
+
+        expect(elements.playlistSourceWrap.classList.contains('opens-upward')).toBe(false);
+        expect(elements.playlistSourceMenu.style.maxHeight).toBe('100px');
+    });
+
     it('lists playlist targets without the queue and appends to the loaded playlist state', async () => {
         const { controller, appendTracksToPlaylistData } = mountPlaylistController();
 
@@ -395,6 +466,9 @@ describe('createPlaylistController', () => {
             '/music/track-2.flac',
         ]);
         expect(controller.getSequenceOverride()).toBeNull();
+        expect(controller.isTrackAlreadyInLoadedPlaylist('/playlists/demo.m3u8', 0)).toBe(true);
+        expect(controller.isTrackAlreadyInLoadedPlaylist('/playlists/demo.m3u8', 2)).toBe(true);
+        expect(controller.isTrackAlreadyInLoadedPlaylist('/playlists/favorite.m3u8', 2)).toBe(false);
     });
 
     it('loads empty playlists without forcing playback and keeps them available as targets', async () => {
@@ -489,6 +563,19 @@ describe('createPlaylistController', () => {
         expect(controller.getSequenceOverride()).toBeNull();
     });
 
+    it('shows an error when prevent duplicates is checked and current track is already in the active playlist', async () => {
+        const { controller, elements, openErrorModal } = mountPlaylistController();
+
+        controller.openModal();
+        elements.playlistPreventDuplicateCheckbox.checked = true;
+        elements.playlistAddCurrent.click();
+
+        expect(openErrorModal).toHaveBeenCalledWith(
+            'Track already in playlist',
+            'The current track is already in the active playlist. Disable duplicate prevention to add it again.',
+        );
+    });
+
     it('hydrates newly visible queue rows after the queue advances', async () => {
         document.body.innerHTML = `${renderPlaylistMenu()}${renderPlaylistModal()}`;
         const trigger = document.createElement('button');
@@ -530,6 +617,7 @@ describe('createPlaylistController', () => {
             savePlaylistTrackMetadataCache: vi.fn(async () => true),
             savePlaylistData: vi.fn(async () => true),
             appendTracksToPlaylistData: vi.fn(async () => true),
+            openErrorModal: vi.fn(),
             getFavoritePlaylists: () => [],
             hasListenHistoryPlaylist: () => false,
             onTrackChosen: vi.fn(async () => undefined),
@@ -583,6 +671,7 @@ describe('createPlaylistController', () => {
             savePlaylistTrackMetadataCache: vi.fn(async () => true),
             savePlaylistData: vi.fn(async () => true),
             appendTracksToPlaylistData: vi.fn(async () => true),
+            openErrorModal: vi.fn(),
             getFavoritePlaylists: () => [],
             hasListenHistoryPlaylist: () => false,
             onTrackChosen: vi.fn(async () => undefined),

--- a/frontend/src/controllers/playlist-controller.ts
+++ b/frontend/src/controllers/playlist-controller.ts
@@ -73,6 +73,7 @@ type PlaylistControllerOptions = {
     savePlaylistTrackMetadataCache: (entries: PlaylistTrackMetadataCacheEntry[]) => Promise<boolean>;
     savePlaylistData: (playlistPath: string, trackPaths: string[]) => Promise<boolean>;
     appendTracksToPlaylistData: (playlistPath: string, trackPaths: string[]) => Promise<boolean>;
+    openErrorModal: (title: string, message: string) => void;
     getFavoritePlaylists: () => string[];
     hasListenHistoryPlaylist: () => boolean;
     onTrackChosen: (index: number, context: PlaylistTrackChosenContext) => Promise<void>;
@@ -105,6 +106,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         playlistHydrationProgress,
         playlistHydrationCount,
         playlistList,
+        playlistPreventDuplicateCheckbox,
         playlistOpen,
         playlistCreate,
         playlistAddCurrent,
@@ -120,6 +122,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
     const queueMutationChunkSize = 512;
     const playlistModalTransitionMs = UI_TIMINGS_MS.modalTransition;
     const playlistViewTransitionMs = 220;
+    const playlistSourceMenuMaxHeightPx = 100;
     const queueVisibleRadius = 50;
     const queueHydrationLookahead = 50;
     let playlistModalHideTimer: number | undefined;
@@ -632,6 +635,8 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
     const closePlaylistSourceMenu = (restoreFocus = false): void => {
         playlistSourceMenu.hidden = true;
         playlistSourceWrap.classList.remove('is-open');
+        playlistSourceWrap.classList.remove('opens-upward');
+        playlistSourceMenu.style.maxHeight = '';
         playlistSourceButton.setAttribute('aria-expanded', 'false');
         if (restoreFocus) {
             playlistSourceButton.focus();
@@ -649,6 +654,21 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
     const openPlaylistSourceMenu = (): void => {
         if (playlistSource.options.length === 0) {
             return;
+        }
+
+        const dialogRect = playlistDialog.getBoundingClientRect();
+        const sourceWrapRect = playlistSourceWrap.getBoundingClientRect();
+        const menuMargin = 8;
+        const spaceBelow = Math.max(0, Math.floor(dialogRect.bottom - sourceWrapRect.bottom - menuMargin));
+        const spaceAbove = Math.max(0, Math.floor(sourceWrapRect.top - dialogRect.top - menuMargin));
+        const shouldOpenUpward = spaceBelow < 180 && spaceAbove > spaceBelow;
+
+        playlistSourceWrap.classList.toggle('opens-upward', shouldOpenUpward);
+        const availableMenuHeight = shouldOpenUpward ? spaceAbove : spaceBelow;
+        if (availableMenuHeight > 0) {
+            playlistSourceMenu.style.maxHeight = `${Math.min(availableMenuHeight, playlistSourceMenuMaxHeightPx)}px`;
+        } else {
+            playlistSourceMenu.style.maxHeight = '';
         }
 
         playlistSourceMenu.hidden = false;
@@ -1158,6 +1178,23 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         return true;
     };
 
+    const isTrackAlreadyInLoadedPlaylist = (playlistPath: string, trackIndex: number): boolean => {
+        const cleanPlaylistPath = playlistPath.trim();
+        if (cleanPlaylistPath === '') {
+            return false;
+        }
+
+        if (!Number.isInteger(trackIndex) || trackIndex < 0 || !controllerState.loadedPlaylistTrackIndexes) {
+            return false;
+        }
+
+        if (normalizePlaylistPath(controllerState.loadedPlaylistPath) !== normalizePlaylistPath(cleanPlaylistPath)) {
+            return false;
+        }
+
+        return controllerState.loadedPlaylistTrackIndexes.includes(trackIndex);
+    };
+
     const enqueueTracks = (trackIndexes: number[], placement: 'next' | 'end'): void => {
         const normalizedTrackIndexes = normalizeQueueEligibleTrackIndexes(trackIndexes);
 
@@ -1277,6 +1314,14 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         }
 
         const activeQueue = mutableCurrentSequence();
+        if (playlistPreventDuplicateCheckbox.checked && activeQueue.includes(currentTrackIndex)) {
+            options.openErrorModal(
+                'Track already in playlist',
+                'The current track is already in the active playlist. Disable duplicate prevention to add it again.',
+            );
+            return;
+        }
+
         activeQueue.push(currentTrackIndex);
         hydrateTrackMetadataInBackground([currentTrackIndex]);
         renderPlaylist(true);
@@ -1781,6 +1826,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             updateHeaderSourceControl();
         },
         getAvailablePlaylistTargets,
+        isTrackAlreadyInLoadedPlaylist,
         appendTracksToPlaylist,
         openPlaylistTarget,
         createPlaylistTarget,

--- a/frontend/src/controllers/playlist-target-modal-controller.test.ts
+++ b/frontend/src/controllers/playlist-target-modal-controller.test.ts
@@ -51,7 +51,34 @@ describe('createPlaylistTargetModalController', () => {
         elements.playlistTargetSelect.value = '/playlists/beta.m3u8';
         elements.playlistTargetConfirm.click();
 
-        await expect(prompt).resolves.toBe('/playlists/beta.m3u8');
+        await expect(prompt).resolves.toEqual({
+            selectedPath: '/playlists/beta.m3u8',
+            duplicatePreventionEnabled: false,
+        });
+    });
+
+    it('returns duplicate-prevention selection when the option is enabled', async () => {
+        document.body.innerHTML = renderPlaylistTargetModal();
+        const elements = getPlaylistTargetModalElements(document);
+        const controller = createPlaylistTargetModalController(elements);
+
+        const prompt = controller.prompt({
+            title: 'Add to playlist',
+            message: 'Add "Track 1" to:',
+            getPlaylists: () => [
+                { path: '/playlists/alpha.m3u8', label: 'alpha.m3u8' },
+            ],
+            duplicatePreventionLabel: 'Block duplicate current track in active playlist',
+        });
+
+        expect(elements.playlistTargetDuplicateWrap.hidden).toBe(false);
+        elements.playlistTargetDuplicateCheckbox.checked = true;
+        elements.playlistTargetConfirm.click();
+
+        await expect(prompt).resolves.toEqual({
+            selectedPath: '/playlists/alpha.m3u8',
+            duplicatePreventionEnabled: true,
+        });
     });
 
     it('shows an empty-state hint and closes on escape when no playlists exist', async () => {
@@ -102,6 +129,9 @@ describe('createPlaylistTargetModalController', () => {
         expect(elements.playlistTargetSelect.value).toBe('/playlists/new-empty.m3u8');
 
         elements.playlistTargetConfirm.click();
-        await expect(prompt).resolves.toBe('/playlists/new-empty.m3u8');
+        await expect(prompt).resolves.toEqual({
+            selectedPath: '/playlists/new-empty.m3u8',
+            duplicatePreventionEnabled: false,
+        });
     });
 });

--- a/frontend/src/controllers/playlist-target-modal-controller.ts
+++ b/frontend/src/controllers/playlist-target-modal-controller.ts
@@ -10,6 +10,13 @@ type PlaylistTargetModalRequest = {
     onOpenPlaylist?: () => Promise<PlaylistTargetOption | null>;
     onCreatePlaylist?: () => Promise<PlaylistTargetOption | null>;
     emptyStateMessage?: string;
+    duplicatePreventionLabel?: string;
+    duplicatePreventionCheckedByDefault?: boolean;
+};
+
+export type PlaylistTargetModalPromptResult = {
+    selectedPath: string;
+    duplicatePreventionEnabled: boolean;
 };
 
 export type PlaylistTargetModalController = ReturnType<typeof createPlaylistTargetModalController>;
@@ -22,6 +29,8 @@ export const createPlaylistTargetModalController = (elements: PlaylistTargetModa
         playlistTargetTitle,
         playlistTargetMessage,
         playlistTargetSelect,
+        playlistTargetDuplicateWrap,
+        playlistTargetDuplicateCheckbox,
         playlistTargetHint,
         playlistTargetOpen,
         playlistTargetCreate,
@@ -31,7 +40,7 @@ export const createPlaylistTargetModalController = (elements: PlaylistTargetModa
 
     const modalTransitionMs = UI_TIMINGS_MS.modalTransition;
     let playlistTargetModalHideTimer: number | undefined;
-    let promptResolver: ((selectedPath: string | null) => void) | null = null;
+    let promptResolver: ((result: PlaylistTargetModalPromptResult | null) => void) | null = null;
     let activeRequest: PlaylistTargetModalRequest | null = null;
     let actionPending = false;
 
@@ -76,17 +85,17 @@ export const createPlaylistTargetModalController = (elements: PlaylistTargetModa
         populatePlaylistOptions(activeRequest?.getPlaylists() || [], selectedPath);
     };
 
-    const resolvePrompt = (selectedPath: string | null): void => {
+    const resolvePrompt = (result: PlaylistTargetModalPromptResult | null): void => {
         if (!promptResolver) {
             return;
         }
 
         const resolver = promptResolver;
         promptResolver = null;
-        resolver(selectedPath);
+        resolver(result);
     };
 
-    const close = (selectedPath: string | null = null): void => {
+    const close = (result: PlaylistTargetModalPromptResult | null = null): void => {
         playlistTargetModal.classList.remove('is-visible');
         activeRequest = null;
         actionPending = false;
@@ -101,10 +110,10 @@ export const createPlaylistTargetModalController = (elements: PlaylistTargetModa
             playlistTargetModalHideTimer = undefined;
         }, modalTransitionMs);
 
-        resolvePrompt(selectedPath);
+        resolvePrompt(result);
     };
 
-    const prompt = (request: PlaylistTargetModalRequest): Promise<string | null> => {
+    const prompt = (request: PlaylistTargetModalRequest): Promise<PlaylistTargetModalPromptResult | null> => {
         resolvePrompt(null);
 
         if (playlistTargetModalHideTimer !== undefined) {
@@ -117,6 +126,13 @@ export const createPlaylistTargetModalController = (elements: PlaylistTargetModa
         playlistTargetTitle.textContent = request.title.trim() || 'Add to playlist';
         playlistTargetMessage.textContent = request.message.trim() || 'Choose a playlist.';
         playlistTargetConfirm.textContent = request.confirmLabel?.trim() || 'Add';
+        const duplicatePreventionLabel = request.duplicatePreventionLabel?.trim() || '';
+        playlistTargetDuplicateWrap.hidden = duplicatePreventionLabel === '';
+        playlistTargetDuplicateCheckbox.checked = request.duplicatePreventionCheckedByDefault === true;
+        const duplicateLabel = playlistTargetDuplicateWrap.querySelector('#playlist-target-duplicate-label');
+        if (duplicateLabel instanceof HTMLSpanElement) {
+            duplicateLabel.textContent = duplicatePreventionLabel;
+        }
         syncActionButtons();
         refreshPlaylistOptions();
 
@@ -131,7 +147,7 @@ export const createPlaylistTargetModalController = (elements: PlaylistTargetModa
             playlistTargetSelect.focus();
         });
 
-        return new Promise<string | null>((resolve) => {
+        return new Promise<PlaylistTargetModalPromptResult | null>((resolve) => {
             promptResolver = resolve;
         });
     };
@@ -199,7 +215,10 @@ export const createPlaylistTargetModalController = (elements: PlaylistTargetModa
             return;
         }
 
-        close(selectedPath);
+        close({
+            selectedPath,
+            duplicatePreventionEnabled: !playlistTargetDuplicateWrap.hidden && playlistTargetDuplicateCheckbox.checked,
+        });
     });
 
     return {


### PR DESCRIPTION
Add duplicate-prevention controls to the playlist flows and surface an error when the current track is already present. Separately, cap the playlist source dropdown to three visible items so opening it cannot shift the modal layout. Validated with npm run validate:ci.

Resolves #61.