### PR TITLE
Add playlist modal search filtering

### DIFF
--- a/frontend/src/components/overlays/overlays.css
+++ b/frontend/src/components/overlays/overlays.css
@@ -2760,7 +2760,11 @@
 }
 
 .playlist-header {
+    --playlist-header-pad-x: 0.9rem;
+    --playlist-header-action-gap: 0.5rem;
+    --playlist-header-icon-btn-size: 1.8rem;
     display: flex;
+    position: relative;
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
@@ -2770,6 +2774,8 @@
 
 .playlist-header-actions {
     display: inline-flex;
+    position: relative;
+    z-index: 3;
     align-items: center;
     gap: 0.5rem;
     flex: 0 0 auto;
@@ -2791,6 +2797,7 @@
     min-width: 0;
     max-width: min(24rem, 65vw);
     flex: 1 1 auto;
+    transition: opacity 180ms ease, filter 180ms ease;
 }
 
 .playlist-source-wrap[hidden] {
@@ -3006,6 +3013,17 @@
 }
 
 .playlist-close {
+    width: var(--playlist-header-icon-btn-size);
+    height: var(--playlist-header-icon-btn-size);
+    border: none;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+}
+
+.playlist-header-icon-btn {
     width: 1.8rem;
     height: 1.8rem;
     border: none;
@@ -3016,10 +3034,109 @@
     cursor: pointer;
 }
 
+.playlist-search-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 160ms ease, color 160ms ease;
+}
+
+.playlist-dialog.is-filter-open .playlist-search-toggle {
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.playlist-filter-panel {
+    position: absolute;
+    top: 50%;
+    right: calc(
+        var(--playlist-header-pad-x)
+        + var(--playlist-header-icon-btn-size)
+        + var(--playlist-header-action-gap)
+        + var(--playlist-header-icon-btn-size)
+        + 0.35rem
+    );
+    width: 0;
+    max-width: calc(100% - 6.1rem);
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(-50%) translateX(0.35rem);
+    pointer-events: none;
+    transition: width 220ms cubic-bezier(0.22, 1, 0.36, 1), opacity 160ms ease, transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+    z-index: 2;
+}
+
+.playlist-dialog.is-filter-open .playlist-filter-panel {
+    width: min(26rem, calc(100% - 6.1rem));
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+    pointer-events: auto;
+}
+
+.playlist-dialog.is-filter-open .playlist-source-wrap {
+    opacity: 0;
+    filter: blur(0.15rem);
+    pointer-events: none;
+}
+
+.playlist-filter-field {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    min-height: 2rem;
+    padding: 0.22rem 0.68rem;
+    box-sizing: border-box;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 0.45rem;
+    background: rgba(0, 0, 0, 0.3);
+    transition: background 150ms ease, border-color 150ms ease;
+}
+
+.playlist-filter-field:focus-within {
+    background: rgba(0, 0, 0, 0.42);
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.playlist-filter-icon {
+    width: 0.82rem;
+    height: 0.82rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255, 255, 255, 0.68);
+    flex: 0 0 auto;
+}
+
+.playlist-filter-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.playlist-filter-input {
+    width: 100%;
+    min-width: 0;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-size: 0.8rem;
+    line-height: 1.25;
+    padding: 0;
+}
+
+.playlist-filter-input:focus {
+    outline: none;
+}
+
+.playlist-filter-input::placeholder {
+    color: rgba(255, 255, 255, 0.48);
+}
+
 .playlist-list {
     list-style: none;
     margin: 0;
-    padding: 0.4rem;
+    padding: 0.4rem 0.4rem 0.5rem;
     overflow: auto;
 }
 
@@ -3126,6 +3243,26 @@
     animation-delay: 72ms;
 }
 
+.playlist-list.is-filtering > .playlist-row,
+.playlist-list.is-filtering > .playlist-item-empty {
+    animation: playlist-filter-results 220ms cubic-bezier(0.2, 0.84, 0.24, 1) both;
+}
+
+.playlist-list.is-filtering > .playlist-row:nth-child(2),
+.playlist-list.is-filtering > .playlist-item-empty:nth-child(2) {
+    animation-delay: 12ms;
+}
+
+.playlist-list.is-filtering > .playlist-row:nth-child(3),
+.playlist-list.is-filtering > .playlist-item-empty:nth-child(3) {
+    animation-delay: 24ms;
+}
+
+.playlist-list.is-filtering > .playlist-row:nth-child(4),
+.playlist-list.is-filtering > .playlist-item-empty:nth-child(4) {
+    animation-delay: 36ms;
+}
+
 @keyframes playlist-view-switch {
     from {
         opacity: 0;
@@ -3140,13 +3277,29 @@
     }
 }
 
+@keyframes playlist-filter-results {
+    from {
+        opacity: 0;
+        transform: translate3d(0, 0.45rem, 0) scale(0.992);
+        filter: blur(0.18rem);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+        filter: blur(0);
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .playlist-dialog {
         transition: opacity 220ms ease, transform 220ms ease;
     }
 
     .playlist-list.is-view-switching > .playlist-row,
-    .playlist-list.is-view-switching > .playlist-item-empty {
+    .playlist-list.is-view-switching > .playlist-item-empty,
+    .playlist-list.is-filtering > .playlist-row,
+    .playlist-list.is-filtering > .playlist-item-empty {
         animation: none;
     }
 }

--- a/frontend/src/components/overlays/playlist-modal.ts
+++ b/frontend/src/components/overlays/playlist-modal.ts
@@ -10,6 +10,8 @@ export type PlaylistModalElements = {
     playlistSourceLabel: HTMLSpanElement;
     playlistSource: HTMLSelectElement;
     playlistSourceMenu: HTMLDivElement;
+    playlistFilterToggle: HTMLButtonElement;
+    playlistFilterInput: HTMLInputElement;
     playlistHydrationProgress: HTMLParagraphElement;
     playlistHydrationCount: HTMLSpanElement;
     playlistList: HTMLUListElement;
@@ -36,11 +38,18 @@ export const renderPlaylistModal = (): string => `
                     <div id="playlist-source-menu" class="playlist-source-menu" role="listbox" hidden></div>
                     <select id="playlist-source" class="playlist-source-native" aria-label="Select playlist view" tabindex="-1" hidden></select>
                 </div>
+                <div class="playlist-filter-panel">
+                    <label class="playlist-filter-field" for="playlist-filter-input">
+                        <span class="playlist-filter-icon" aria-hidden="true"><svg width="12" height="12" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M10.5 4.25C7.05 4.25 4.25 7.05 4.25 10.5C4.25 13.95 7.05 16.75 10.5 16.75C11.99 16.75 13.36 16.23 14.44 15.36L18.54 19.46C18.83 19.75 19.3 19.75 19.59 19.46C19.89 19.17 19.89 18.7 19.59 18.41L15.49 14.31C16.36 13.23 16.88 11.86 16.88 10.38C16.88 6.94 14.07 4.25 10.5 4.25ZM5.75 10.5C5.75 7.88 7.88 5.75 10.5 5.75C13.12 5.75 15.25 7.88 15.25 10.5C15.25 13.12 13.12 15.25 10.5 15.25C7.88 15.25 5.75 13.12 5.75 10.5Z"/></svg></span>
+                        <input id="playlist-filter-input" class="playlist-filter-input" type="search" placeholder="Filter tracks in this view" aria-label="Filter tracks in the current playlist view" spellcheck="false" autocomplete="off">
+                    </label>
+                </div>
                 <div class="playlist-header-actions">
                     <p id="playlist-hydration-progress" class="playlist-hydration-progress" hidden aria-live="polite">
                         <span class="playlist-hydration-spinner" aria-hidden="true"></span>
                         <span id="playlist-hydration-count" class="playlist-hydration-count">0 of 0</span>
                     </p>
+                    <button id="playlist-filter-toggle" class="playlist-header-icon-btn playlist-search-toggle" type="button" aria-label="Search playlist" aria-controls="playlist-filter-input" aria-expanded="false"><svg class="overlay-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M10.5 4.25C7.05 4.25 4.25 7.05 4.25 10.5C4.25 13.95 7.05 16.75 10.5 16.75C11.99 16.75 13.36 16.23 14.44 15.36L18.54 19.46C18.83 19.75 19.3 19.75 19.59 19.46C19.89 19.17 19.89 18.7 19.59 18.41L15.49 14.31C16.36 13.23 16.88 11.86 16.88 10.38C16.88 6.94 14.07 4.25 10.5 4.25ZM5.75 10.5C5.75 7.88 7.88 5.75 10.5 5.75C13.12 5.75 15.25 7.88 15.25 10.5C15.25 13.12 13.12 15.25 10.5 15.25C7.88 15.25 5.75 13.12 5.75 10.5Z"/></svg></button>
                     <button id="playlist-close" class="playlist-close" type="button" aria-label="Close playlist"><svg class="overlay-icon" width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M6.4 5.34C6.11 5.05 5.64 5.05 5.34 5.34C5.05 5.64 5.05 6.11 5.34 6.4L10.94 12L5.34 17.6C5.05 17.89 5.05 18.36 5.34 18.66C5.64 18.95 6.11 18.95 6.4 18.66L12 13.06L17.6 18.66C17.89 18.95 18.36 18.95 18.66 18.66C18.95 18.36 18.95 17.89 18.66 17.6L13.06 12L18.66 6.4C18.95 6.11 18.95 5.64 18.66 5.34C18.36 5.05 17.89 5.05 17.6 5.34L12 10.94L6.4 5.34Z"/></svg></button>
                 </div>
             </header>
@@ -75,6 +84,8 @@ export const getPlaylistModalElements = (root: ParentNode): PlaylistModalElement
     playlistSourceLabel: root.querySelector('#playlist-source-label') as HTMLSpanElement,
     playlistSource: root.querySelector('#playlist-source') as HTMLSelectElement,
     playlistSourceMenu: root.querySelector('#playlist-source-menu') as HTMLDivElement,
+    playlistFilterToggle: root.querySelector('#playlist-filter-toggle') as HTMLButtonElement,
+    playlistFilterInput: root.querySelector('#playlist-filter-input') as HTMLInputElement,
     playlistHydrationProgress: root.querySelector('#playlist-hydration-progress') as HTMLParagraphElement,
     playlistHydrationCount: root.querySelector('#playlist-hydration-count') as HTMLSpanElement,
     playlistList: root.querySelector('#playlist-list') as HTMLUListElement,

--- a/frontend/src/controllers/playlist-controller.test.ts
+++ b/frontend/src/controllers/playlist-controller.test.ts
@@ -325,6 +325,89 @@ describe('createPlaylistController', () => {
         expect(elements.playlistSource.value).toBe('queue');
     });
 
+    it('filters the current playlist view and clears the filter when the modal closes', () => {
+        const { controller, elements } = mountPlaylistController();
+        vi.useFakeTimers();
+
+        controller.openModal();
+        elements.playlistFilterToggle.click();
+        expect(elements.playlistFilterToggle.getAttribute('aria-expanded')).toBe('true');
+        expect(elements.playlistDialog.classList.contains('is-filter-open')).toBe(true);
+        elements.playlistFilterInput.value = 'Track 2';
+        elements.playlistFilterInput.dispatchEvent(new Event('input', { bubbles: true }));
+        vi.advanceTimersByTime(300);
+
+        expect(Array.from(elements.playlistList.querySelectorAll<HTMLButtonElement>('[data-playlist-track-index]')).map((button) => button.dataset.playlistTrackIndex)).toEqual(['2']);
+
+        controller.closeModal();
+        controller.openModal();
+
+        expect(elements.playlistFilterToggle.getAttribute('aria-expanded')).toBe('false');
+        expect(elements.playlistDialog.classList.contains('is-filter-open')).toBe(false);
+        expect(elements.playlistFilterInput.value).toBe('');
+        expect(Array.from(elements.playlistList.querySelectorAll<HTMLButtonElement>('[data-playlist-track-index]')).map((button) => button.dataset.playlistTrackIndex)).toEqual(['0', '1', '2']);
+        vi.useRealTimers();
+    });
+
+    it('waits 300ms after the last typed character before applying the filter', () => {
+        const { controller, elements } = mountPlaylistController();
+        vi.useFakeTimers();
+
+        controller.openModal();
+        elements.playlistFilterToggle.click();
+        elements.playlistFilterInput.value = 'Track 2';
+        elements.playlistFilterInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(Array.from(elements.playlistList.querySelectorAll<HTMLButtonElement>('[data-playlist-track-index]')).map((button) => button.dataset.playlistTrackIndex)).toEqual(['0', '1', '2']);
+
+        vi.advanceTimersByTime(299);
+        expect(Array.from(elements.playlistList.querySelectorAll<HTMLButtonElement>('[data-playlist-track-index]')).map((button) => button.dataset.playlistTrackIndex)).toEqual(['0', '1', '2']);
+        expect(elements.playlistList.classList.contains('is-filtering')).toBe(false);
+
+        vi.advanceTimersByTime(1);
+        expect(Array.from(elements.playlistList.querySelectorAll<HTMLButtonElement>('[data-playlist-track-index]')).map((button) => button.dataset.playlistTrackIndex)).toEqual(['2']);
+        expect(elements.playlistList.classList.contains('is-filtering')).toBe(true);
+
+        vi.advanceTimersByTime(170);
+        expect(elements.playlistList.classList.contains('is-filtering')).toBe(false);
+        vi.useRealTimers();
+    });
+
+    it('clears the filter when the playlist source is switched', async () => {
+        const { controller, elements } = mountPlaylistController();
+        vi.useFakeTimers();
+
+        controller.openModal();
+        elements.playlistFilterToggle.click();
+        elements.playlistFilterInput.value = 'Track 2';
+        elements.playlistFilterInput.dispatchEvent(new Event('input', { bubbles: true }));
+        vi.advanceTimersByTime(300);
+        await selectCustomPlaylistSource(elements, 'favorite:0');
+
+        expect(elements.playlistFilterToggle.getAttribute('aria-expanded')).toBe('false');
+        expect(elements.playlistFilterInput.value).toBe('');
+        expect(Array.from(elements.playlistList.querySelectorAll<HTMLButtonElement>('[data-playlist-track-index]')).map((button) => button.dataset.playlistTrackIndex)).toEqual(['1', '0']);
+        vi.useRealTimers();
+    });
+
+    it('clears the filter when a different playlist path is loaded directly', async () => {
+        const { controller, elements } = mountPlaylistController();
+        vi.useFakeTimers();
+
+        await expect(controller.loadPlaylistByPath('/playlists/demo.m3u8')).resolves.toBe(true);
+        elements.playlistFilterToggle.click();
+        elements.playlistFilterInput.value = 'Track 2';
+        elements.playlistFilterInput.dispatchEvent(new Event('input', { bubbles: true }));
+        vi.advanceTimersByTime(300);
+
+        await expect(controller.loadPlaylistByPath('/playlists/empty.m3u8')).resolves.toBe(true);
+
+        expect(elements.playlistFilterToggle.getAttribute('aria-expanded')).toBe('false');
+        expect(elements.playlistFilterInput.value).toBe('');
+        expect(elements.playlistList.textContent).toContain('No tracks available');
+        vi.useRealTimers();
+    });
+
     it('loads listen history as a read-only playlist source', async () => {
         const { controller, elements, loadListenHistoryData, onTrackChosen } = mountPlaylistController();
         vi.useFakeTimers();

--- a/frontend/src/controllers/playlist-controller.ts
+++ b/frontend/src/controllers/playlist-controller.ts
@@ -103,6 +103,8 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         playlistSourceLabel,
         playlistSource,
         playlistSourceMenu,
+        playlistFilterToggle,
+        playlistFilterInput,
         playlistHydrationProgress,
         playlistHydrationCount,
         playlistList,
@@ -121,13 +123,19 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
     let hydrationSignature = '';
     const queueMutationChunkSize = 512;
     const playlistModalTransitionMs = UI_TIMINGS_MS.modalTransition;
+    const playlistFilterTransitionMs = 170;
     const playlistViewTransitionMs = 220;
+    const playlistFilterDebounceMs = 300;
     const playlistSourceMenuMaxHeightPx = 100;
     const queueVisibleRadius = 50;
     const queueHydrationLookahead = 50;
     let playlistModalHideTimer: number | undefined;
+    let playlistFilterTransitionTimer: number | undefined;
     let playlistViewTransitionTimer: number | undefined;
     let playlistDialogResizeTimer: number | undefined;
+    let playlistFilterDebounceTimer: number | undefined;
+    let playlistFilterExpanded = false;
+    let playlistFilterQuery = '';
     const playlistPrefixIcon = (state: 'active' | 'before' | 'after'): string => {
         if (state === 'active') {
             return '<svg class="playlist-inline-icon" width="11" height="11" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M12 7C9.24 7 7 9.24 7 12C7 14.76 9.24 17 12 17C14.76 17 17 14.76 17 12C17 9.24 14.76 7 12 7Z"/></svg>';
@@ -442,6 +450,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.playbackSource = 'queue';
         controllerState.selectedFavoriteIndex = null;
         dragFromPosition = null;
+        clearPlaylistFilter();
         options.onExternalPlaylistLoaded();
         hydrateTrackMetadataInBackground(sanitizedPlaylist.trackIndexes);
 
@@ -469,6 +478,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.playbackSource = 'queue';
         controllerState.selectedFavoriteIndex = null;
         dragFromPosition = null;
+        clearPlaylistFilter();
         hydrateTrackMetadataInBackground(sanitizedPlaylist.trackIndexes);
 
         renderPlaylist(true);
@@ -546,6 +556,76 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
 
         playlistSourceIcon.innerHTML = '';
         playlistSourceIcon.classList.remove('is-visible');
+    };
+
+    const normalizePlaylistFilterQuery = (value: string): string => value.trim().toLocaleLowerCase();
+
+    const syncPlaylistFilterUi = (): void => {
+        playlistDialog.classList.toggle('is-filter-open', playlistFilterExpanded);
+        playlistFilterToggle.setAttribute('aria-expanded', playlistFilterExpanded ? 'true' : 'false');
+        playlistFilterInput.tabIndex = playlistFilterExpanded ? 0 : -1;
+    };
+
+    const setPlaylistFilterExpanded = (expanded: boolean, focusInput = false): void => {
+        playlistFilterExpanded = expanded;
+        syncPlaylistFilterUi();
+        if (focusInput && playlistFilterExpanded) {
+            window.requestAnimationFrame(() => {
+                playlistFilterInput.focus();
+                playlistFilterInput.select();
+            });
+        }
+    };
+
+    const cancelPendingPlaylistFilterUpdate = (): void => {
+        if (playlistFilterDebounceTimer === undefined) {
+            return;
+        }
+
+        window.clearTimeout(playlistFilterDebounceTimer);
+        playlistFilterDebounceTimer = undefined;
+    };
+
+    const hasPlaylistFilterText = (): boolean => {
+        return normalizePlaylistFilterQuery(playlistFilterInput.value) !== '' || normalizePlaylistFilterQuery(playlistFilterQuery) !== '';
+    };
+
+    const clearPlaylistFilter = (): void => {
+        cancelPendingPlaylistFilterUpdate();
+        playlistFilterQuery = '';
+        playlistFilterInput.value = '';
+        setPlaylistFilterExpanded(false);
+    };
+
+    const playlistFilterTerms = (): string[] => {
+        const normalizedQuery = normalizePlaylistFilterQuery(playlistFilterQuery);
+        if (normalizedQuery === '') {
+            return [];
+        }
+
+        return normalizedQuery.split(/\s+/).filter((term) => term !== '');
+    };
+
+    const matchesPlaylistFilter = (
+        trackIndex: number,
+        cachedItemsByTrackIndex: Map<number, LoadedPlaylistCachedItem>,
+        filterTerms: string[],
+    ): boolean => {
+        if (filterTerms.length === 0) {
+            return true;
+        }
+
+        const track = options.getTrack(trackIndex);
+        const cachedItem = cachedItemsByTrackIndex.get(trackIndex);
+        const searchableText = [
+            track?.displayTitle || '',
+            track?.name || '',
+            track?.displayArtist || '',
+            cachedItem?.cachedTrackTitle || '',
+            cachedItem?.cachedArtistName || '',
+        ].join('\n').toLocaleLowerCase();
+
+        return filterTerms.every((term) => searchableText.includes(term));
     };
 
     const getPlaylistSourceControlOptions = (): PlaylistSourceControlOption[] => {
@@ -678,6 +758,10 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
     };
 
     const togglePlaylistSourceMenu = (): void => {
+        if (playlistFilterExpanded) {
+            return;
+        }
+
         if (playlistSourceMenu.hidden) {
             openPlaylistSourceMenu();
             return;
@@ -690,6 +774,8 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         if (!setPlaylistSourceSelection(selectedValue)) {
             return;
         }
+
+        clearPlaylistFilter();
 
         if (selectedValue === 'queue') {
             controllerState.selectedSource = 'queue';
@@ -786,6 +872,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
 
     const closeModal = (): void => {
         closePlaylistSourceMenu();
+        clearPlaylistFilter();
         playlistModal.classList.remove('is-visible');
 
         if (playlistModalHideTimer !== undefined) {
@@ -859,9 +946,30 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         }, playlistViewTransitionMs);
     };
 
-    const renderPlaylist = (animateViewSwitch = false): void => {
-        const previousDialogHeight = animateViewSwitch ? playlistDialog.getBoundingClientRect().height : 0;
-        if (animateViewSwitch) {
+    const animatePlaylistFilterResults = (): void => {
+        if (playlistModal.hidden || prefersReducedMotion()) {
+            return;
+        }
+
+        if (playlistFilterTransitionTimer !== undefined) {
+            window.clearTimeout(playlistFilterTransitionTimer);
+            playlistFilterTransitionTimer = undefined;
+        }
+
+        playlistList.classList.remove('is-filtering');
+        void playlistList.offsetWidth;
+        playlistList.classList.add('is-filtering');
+
+        playlistFilterTransitionTimer = window.setTimeout(() => {
+            playlistList.classList.remove('is-filtering');
+            playlistFilterTransitionTimer = undefined;
+        }, playlistFilterTransitionMs);
+    };
+
+    const renderPlaylist = (animateViewSwitch = false, animateFilterResults = false): void => {
+        const shouldAnimateDialog = animateViewSwitch;
+        const previousDialogHeight = shouldAnimateDialog ? playlistDialog.getBoundingClientRect().height : 0;
+        if (shouldAnimateDialog) {
             if (playlistDialogResizeTimer !== undefined) {
                 window.clearTimeout(playlistDialogResizeTimer);
                 playlistDialogResizeTimer = undefined;
@@ -880,13 +988,33 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         const start = viewingPlaylist ? 0 : Math.max(0, anchorPosition - queueVisibleRadius);
         const end = viewingPlaylist ? indexes.length : Math.min(indexes.length, anchorPosition + queueVisibleRadius + 1);
         const cachedItemsByTrackIndex = cachedPlaylistItemsByTrackIndex();
+        const filterTerms = playlistFilterTerms();
 
         let visibleRows: RenderablePlaylistRow[];
-        if (viewingPlaylist) {
-            visibleRows = indexes.slice(start, end).map((trackIndex, offset) => ({
-                actualPosition: start + offset,
-                trackIndex,
-            }));
+        if (viewingPlaylist || filterTerms.length > 0) {
+            if (!viewingPlaylist) {
+                const hydrationEnd = Math.min(indexes.length, end + queueHydrationLookahead);
+                requestTrackMetadataHydration(indexes.slice(start, hydrationEnd));
+            }
+
+            const nextVisibleRows: RenderablePlaylistRow[] = [];
+            for (let position = 0; position < indexes.length; position += 1) {
+                const trackIndex = indexes[position];
+                if (!viewingPlaylist && trackIndex !== currentTrackIndex && !hasAuthoritativeTrackLabels(trackIndex, cachedItemsByTrackIndex)) {
+                    continue;
+                }
+
+                if (!matchesPlaylistFilter(trackIndex, cachedItemsByTrackIndex, filterTerms)) {
+                    continue;
+                }
+
+                nextVisibleRows.push({
+                    actualPosition: position,
+                    trackIndex,
+                });
+            }
+
+            visibleRows = nextVisibleRows;
         } else {
             const hydrationEnd = Math.min(indexes.length, end + queueHydrationLookahead);
             requestTrackMetadataHydration(indexes.slice(start, hydrationEnd));
@@ -908,13 +1036,17 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         }
 
         if (visibleRows.length === 0) {
-            const emptyMessage = !viewingPlaylist && indexes.length > 0
+            const emptyMessage = filterTerms.length > 0
+                ? 'No matching tracks'
+                : !viewingPlaylist && indexes.length > 0
                 ? 'Loading queue metadata…'
                 : 'No tracks available';
             playlistList.innerHTML = `<li class="playlist-item-empty">${emptyMessage}</li>`;
             if (animateViewSwitch) {
                 animatePlaylistDialogResize(previousDialogHeight);
                 animatePlaylistViewSwitch();
+            } else if (animateFilterResults) {
+                animatePlaylistFilterResults();
             }
             return;
         }
@@ -950,6 +1082,8 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         if (animateViewSwitch) {
             animatePlaylistDialogResize(previousDialogHeight);
             animatePlaylistViewSwitch();
+        } else if (animateFilterResults) {
+            animatePlaylistFilterResults();
         }
     };
 
@@ -1289,6 +1423,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.playbackSource = 'queue';
         hydrationRunId += 1;
         dragFromPosition = null;
+        clearPlaylistFilter();
         scheduleRender();
     };
 
@@ -1376,6 +1511,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.playbackSource = 'queue';
         controllerState.editableQueueTrackIndexes = null;
         controllerState.selectedFavoriteIndex = null;
+        clearPlaylistFilter();
         hydrateTrackMetadataInBackground([]);
         renderPlaylist(true);
     };
@@ -1401,6 +1537,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.selectedSource = 'playlist';
         controllerState.playbackSource = 'queue';
         dragFromPosition = null;
+        clearPlaylistFilter();
         hydrateTrackMetadataInBackground(sanitizedPlaylist.trackIndexes);
         renderPlaylist(true);
     };
@@ -1430,6 +1567,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.loadedPlaylistHistoryItems = null;
         controllerState.loadedPlaylistCachedItems = sanitizedPlaylist.cachedItems || null;
         controllerState.selectedFavoriteIndex = null;
+        clearPlaylistFilter();
         updateHeaderSourceControl();
         scheduleRender();
 
@@ -1476,6 +1614,8 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         const favoriteValue = `favorite:${favoriteIndex}`;
         setPlaylistSourceSelection(favoriteValue);
     };
+
+    syncPlaylistFilterUi();
 
     trigger.addEventListener('click', () => {
         openModal();
@@ -1573,6 +1713,45 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             event.preventDefault();
             activeElement?.click();
         }
+    });
+
+    playlistFilterToggle.addEventListener('click', () => {
+        if (playlistFilterExpanded) {
+            const hadActiveQuery = hasPlaylistFilterText();
+            clearPlaylistFilter();
+            if (hadActiveQuery) {
+                renderPlaylist(false, true);
+            }
+            playlistFilterToggle.focus();
+            return;
+        }
+
+        closePlaylistSourceMenu();
+        setPlaylistFilterExpanded(true, true);
+    });
+
+    playlistFilterInput.addEventListener('input', () => {
+        cancelPendingPlaylistFilterUpdate();
+        const nextFilterQuery = playlistFilterInput.value;
+        playlistFilterDebounceTimer = window.setTimeout(() => {
+            playlistFilterDebounceTimer = undefined;
+            playlistFilterQuery = nextFilterQuery;
+            renderPlaylist(false, true);
+        }, playlistFilterDebounceMs);
+    });
+
+    playlistFilterInput.addEventListener('keydown', (event) => {
+        if (event.key !== 'Escape') {
+            return;
+        }
+
+        event.preventDefault();
+        const hadActiveQuery = hasPlaylistFilterText();
+        clearPlaylistFilter();
+        if (hadActiveQuery) {
+            renderPlaylist(false, true);
+        }
+        playlistFilterToggle.focus();
     });
 
     document.addEventListener('pointerdown', (event) => {


### PR DESCRIPTION
Move playlist filtering into a header search toggle, debounce input updates, and reset filter state when the modal context changes. Add a lightweight filtered-results animation without resizing the dialog. Validated with npm run test:frontend -- src/controllers/playlist-controller.test.ts, npm run lint:frontend, and npm run build:frontend.

Resolves #60.