### PR TITLE
Fix playback queue dragging and shuffle state

### DIFF
--- a/audio_backend_playback_additional_test.go
+++ b/audio_backend_playback_additional_test.go
@@ -345,7 +345,6 @@ func TestLoadTrackFromDecodeSourceStreamsRemoteBeforeComplete(t *testing.T) {
 	t.Setenv("SILPHIUM_TEST_FFMPEG_STDERR", "")
 	t.Setenv("SILPHIUM_TEST_FFMPEG_EXIT", "0")
 
-	startedAt := time.Now()
 	state, err := backend.loadTrackFromDecodeSource(
 		"silphium-remote://friend:41637/Library/Artist/Album/01 Remote.flac",
 		"https://example.invalid/remote.flac",
@@ -362,12 +361,13 @@ func TestLoadTrackFromDecodeSourceStreamsRemoteBeforeComplete(t *testing.T) {
 
 	backend.mutex.Lock()
 	bufferedBytes := len(backend.streamSegments[0].PCMData)
+	decodeDoneAtReturn := backend.streamDecodeDone
 	backend.mutex.Unlock()
 	if bufferedBytes >= 4*audioBytesPerSecond {
 		t.Fatalf("loadTrackFromDecodeSource(progressive remote) buffered bytes = %d, want partial buffer before full decode completes", bufferedBytes)
 	}
-	if elapsed := time.Since(startedAt); elapsed >= 450*time.Millisecond {
-		t.Fatalf("loadTrackFromDecodeSource(progressive remote) elapsed = %s, want to return before full decode finishes", elapsed)
+	if decodeDoneAtReturn {
+		t.Fatalf("loadTrackFromDecodeSource(progressive remote) returned after decode completed; buffered bytes = %d", bufferedBytes)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)

--- a/frontend/src/app-bootstrap-setup.test.ts
+++ b/frontend/src/app-bootstrap-setup.test.ts
@@ -57,6 +57,7 @@ const createScope = () => {
             loadedPlaylistHistoryItems: null,
             loadedPlaylistCachedItems: null,
             editableQueueTrackIndexes: null,
+            editableQueueCurrentPosition: null,
             selectedSource: 'queue',
             selectedFavoriteIndex: null,
             playbackSource: 'queue',

--- a/frontend/src/app-controller-setup.test.ts
+++ b/frontend/src/app-controller-setup.test.ts
@@ -136,6 +136,7 @@ const createContext = () => {
             loadedPlaylistHistoryItems: null,
             loadedPlaylistCachedItems: null,
             editableQueueTrackIndexes: null,
+            editableQueueCurrentPosition: null,
             selectedSource: 'queue',
             selectedFavoriteIndex: null,
             playbackSource: 'queue',

--- a/frontend/src/app-state.test.ts
+++ b/frontend/src/app-state.test.ts
@@ -41,6 +41,7 @@ describe('createAppState', () => {
             loadedPlaylistHistoryItems: null,
             loadedPlaylistCachedItems: null,
             editableQueueTrackIndexes: null,
+            editableQueueCurrentPosition: null,
             selectedSource: 'queue',
             selectedFavoriteIndex: null,
             playbackSource: 'queue',

--- a/frontend/src/components/overlays/overlays.css
+++ b/frontend/src/components/overlays/overlays.css
@@ -3381,6 +3381,10 @@
     opacity: 0.55;
 }
 
+.playlist-row.is-drop-target .playlist-item {
+    background: rgba(255, 255, 255, 0.16);
+}
+
 .playlist-drag-handle,
 .playlist-remove {
     border: none;
@@ -3405,6 +3409,8 @@
 
 .playlist-drag-handle {
     cursor: grab;
+    touch-action: none;
+    user-select: none;
 }
 
 .playlist-drag-handle:active {

--- a/frontend/src/controllers/playlist-controller-state.ts
+++ b/frontend/src/controllers/playlist-controller-state.ts
@@ -17,6 +17,7 @@ export type PlaylistControllerState = {
     loadedPlaylistHistoryItems: LoadedListenHistoryItem[] | null;
     loadedPlaylistCachedItems: LoadedPlaylistCachedItem[] | null;
     editableQueueTrackIndexes: number[] | null;
+    editableQueueCurrentPosition: number | null;
     selectedSource: PlaylistSource;
     selectedFavoriteIndex: number | null;
     playbackSource: PlaylistSource;
@@ -30,6 +31,7 @@ export const createPlaylistControllerState = (): PlaylistControllerState => ({
     loadedPlaylistHistoryItems: null,
     loadedPlaylistCachedItems: null,
     editableQueueTrackIndexes: null,
+    editableQueueCurrentPosition: null,
     selectedSource: 'queue',
     selectedFavoriteIndex: null,
     playbackSource: 'queue',

--- a/frontend/src/controllers/playlist-controller.test.ts
+++ b/frontend/src/controllers/playlist-controller.test.ts
@@ -11,6 +11,21 @@ const flushPromises = async (): Promise<void> => {
     await Promise.resolve();
 };
 
+const dispatchPointerEvent = (
+    target: EventTarget,
+    type: string,
+    init: Partial<{ button: number; clientX: number; clientY: number; pointerId: number }> = {},
+): void => {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperties(event, {
+        button: { value: init.button ?? 0 },
+        clientX: { value: init.clientX ?? 0 },
+        clientY: { value: init.clientY ?? 0 },
+        pointerId: { value: init.pointerId ?? 1 },
+    });
+    target.dispatchEvent(event);
+};
+
 const selectCustomPlaylistSource = async (
     elements: ReturnType<typeof getPlaylistModalElements>,
     value: string,
@@ -660,7 +675,114 @@ describe('createPlaylistController', () => {
         );
     });
 
-    it('renders the playback queue from the current track through the next 50 tracks', async () => {
+    it('starts queue dragging from the handle instead of the full row', () => {
+        const { controller, elements } = mountPlaylistController();
+
+        controller.openModal();
+
+        const rows = Array.from(elements.playlistList.querySelectorAll<HTMLLIElement>('.playlist-row'));
+        const row = rows[0] || null;
+        const handle = row?.querySelector('.playlist-drag-handle') as HTMLButtonElement | null;
+        const nextHandle = rows[1]?.querySelector('.playlist-drag-handle') as HTMLButtonElement | null;
+
+        expect(row).not.toBeNull();
+        expect(handle).not.toBeNull();
+        expect(row?.draggable).toBe(false);
+        expect(handle?.draggable).toBe(false);
+        expect(handle?.disabled).toBe(true);
+        expect(nextHandle?.disabled).toBe(false);
+    });
+
+    it('does not allow dragging the currently playing track in the playback queue', () => {
+        const { controller, elements } = mountPlaylistController();
+
+        controller.openModal();
+
+        const sourceRow = elements.playlistList.querySelector('[data-playlist-position="0"]') as HTMLLIElement | null;
+        const targetRow = elements.playlistList.querySelector('[data-playlist-position="1"]') as HTMLLIElement | null;
+        const handle = sourceRow?.querySelector('.playlist-drag-handle') as HTMLButtonElement | null;
+
+        expect(sourceRow).not.toBeNull();
+        expect(targetRow).not.toBeNull();
+        expect(handle).not.toBeNull();
+        expect(handle?.disabled).toBe(true);
+
+        Object.defineProperty(document, 'elementFromPoint', {
+            value: vi.fn(() => targetRow),
+            configurable: true,
+        });
+
+        dispatchPointerEvent(handle as HTMLButtonElement, 'pointerdown', { pointerId: 5, clientX: 10, clientY: 10 });
+        dispatchPointerEvent(window, 'pointermove', { pointerId: 5, clientX: 20, clientY: 20 });
+        dispatchPointerEvent(window, 'pointerup', { pointerId: 5, clientX: 20, clientY: 20 });
+
+        expect(controller.getSequenceOverride()).toBeNull();
+        expect(Array.from(elements.playlistList.querySelectorAll<HTMLButtonElement>('[data-playlist-track-index]')).map((button) => Number(button.dataset.playlistTrackIndex))).toEqual([0, 1, 2]);
+    });
+
+    it('preserves the active queue cursor when pointer-dragging a shuffled queue with duplicate track indexes', () => {
+        document.body.innerHTML = `${renderPlaylistMenu()}${renderPlaylistModal()}`;
+        const trigger = document.createElement('button');
+        document.body.append(trigger);
+
+        const menu = getPlaylistMenuElements(document);
+        const modal = getPlaylistModalElements(document);
+        const trackViews = [createTrackView(0), createTrackView(1), createTrackView(2), createTrackView(3), createTrackView(4)];
+
+        const controller = createPlaylistController({
+            trigger,
+            menu,
+            modal,
+            getTrack: (index: number) => trackViews[index],
+            getTrackPath: (index: number) => `/music/track-${index}.flac`,
+            getTrackCount: () => trackViews.length,
+            getCurrentTrackIndex: () => 1,
+            getPlaybackOrderLabel: () => 'Shuffle',
+            getBaseSequence: () => ({
+                indexes: [2, 1, 3, 1, 4],
+                currentPosition: 3,
+            }),
+            ensureTrackTagsResolvedBatch: vi.fn(async () => undefined),
+            selectPlaylistFile: vi.fn(async () => ''),
+            selectPlaylistSaveFile: vi.fn(async () => ''),
+            loadPlaylistData: vi.fn(async () => null),
+            loadListenHistoryData: vi.fn(async () => null),
+            savePlaylistTrackMetadataCache: vi.fn(async () => true),
+            savePlaylistData: vi.fn(async () => true),
+            appendTracksToPlaylistData: vi.fn(async () => true),
+            openErrorModal: vi.fn(),
+            getFavoritePlaylists: () => [],
+            hasListenHistoryPlaylist: () => false,
+            onTrackChosen: vi.fn(async () => undefined),
+            onExternalPlaylistLoaded: vi.fn(() => undefined),
+        });
+
+        controller.openModal();
+
+    const sourceRow = modal.playlistList.querySelector('[data-playlist-position="4"]') as HTMLLIElement | null;
+    const targetRow = modal.playlistList.querySelector('[data-playlist-position="3"]') as HTMLLIElement | null;
+        const handle = sourceRow?.querySelector('.playlist-drag-handle') as HTMLButtonElement | null;
+
+        expect(sourceRow).not.toBeNull();
+        expect(targetRow).not.toBeNull();
+        expect(handle).not.toBeNull();
+        Object.defineProperty(document, 'elementFromPoint', {
+            value: vi.fn(() => targetRow),
+            configurable: true,
+        });
+
+        dispatchPointerEvent(handle as HTMLButtonElement, 'pointerdown', { pointerId: 7, clientX: 10, clientY: 10 });
+        dispatchPointerEvent(window, 'pointermove', { pointerId: 7, clientX: 20, clientY: 20 });
+        dispatchPointerEvent(window, 'pointerup', { pointerId: 7, clientX: 20, clientY: 20 });
+
+        expect(controller.getSequenceOverride()).toEqual({
+            indexes: [2, 1, 3, 4, 1],
+            currentPosition: 4,
+        });
+        expect(Array.from(modal.playlistList.querySelectorAll<HTMLButtonElement>('[data-playlist-track-index]')).map((button) => Number(button.dataset.playlistTrackIndex))).toEqual([2, 1, 3, 4, 1]);
+    });
+
+    it('renders the playback queue with up to 50 previous and 50 next tracks around the current cursor', async () => {
         document.body.innerHTML = `${renderPlaylistMenu()}${renderPlaylistModal()}`;
         const trigger = document.createElement('button');
         document.body.append(trigger);
@@ -708,7 +830,7 @@ describe('createPlaylistController', () => {
         const renderedIndexes = Array.from(modal.playlistList.querySelectorAll<HTMLButtonElement>('[data-playlist-track-index]'))
             .map((button) => Number(button.dataset.playlistTrackIndex));
 
-        expect(renderedIndexes).toEqual(Array.from({ length: 51 }, (_, offset) => 50 + offset));
+        expect(renderedIndexes).toEqual(Array.from({ length: 101 }, (_, index) => index));
     });
 
     it('hydrates newly visible queue rows after the queue advances', async () => {

--- a/frontend/src/controllers/playlist-controller.ts
+++ b/frontend/src/controllers/playlist-controller.ts
@@ -47,6 +47,12 @@ type RenderablePlaylistRow = {
     trackIndex: number;
 };
 
+type QueueDragState = {
+    fromPosition: number;
+    targetPosition: number;
+    pointerId: number;
+};
+
 type PlaylistVisibleWindow = {
     start: number;
     end: number;
@@ -127,7 +133,8 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
     const playlistHeader = playlistHydrationProgress.closest('.playlist-header') as HTMLElement | null;
 
     let hydrationRunId = 0;
-    let dragFromPosition: number | null = null;
+    let queueDragState: QueueDragState | null = null;
+    let deferredRenderDuringQueueDrag = false;
     let hydrationTotal = 0;
     let hydrationCompleted = 0;
     let hydrationHideToken = 0;
@@ -138,7 +145,9 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
     const playlistViewTransitionMs = 220;
     const playlistFilterDebounceMs = 300;
     const playlistSourceMenuMaxHeightPx = 100;
+    const queueVisiblePreviousCount = 50;
     const queueVisibleAheadCount = 50;
+    const queueHydrationLookbehind = 50;
     const queueHydrationLookahead = 50;
     const playlistHydrationVisibleRows = 72;
     const playlistHydrationOverscan = 24;
@@ -454,6 +463,184 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
 
     const isViewingReadOnlyPlaylist = (): boolean => controllerState.selectedSource === 'history' && controllerState.loadedPlaylistReadOnly;
 
+    const clearEditableQueueState = (): void => {
+        controllerState.editableQueueTrackIndexes = null;
+        controllerState.editableQueueCurrentPosition = null;
+    };
+
+    const clampEditableQueuePosition = (queueIndexes: number[], position: number | null): number => {
+        if (queueIndexes.length === 0) {
+            return 0;
+        }
+
+        if (!Number.isInteger(position)) {
+            return 0;
+        }
+
+        return Math.min(Math.max(position as number, 0), queueIndexes.length - 1);
+    };
+
+    const setEditableQueueState = (queueIndexes: number[], currentPosition: number): number[] => {
+        if (queueIndexes.length === 0) {
+            clearEditableQueueState();
+            return [];
+        }
+
+        controllerState.editableQueueTrackIndexes = queueIndexes;
+        controllerState.editableQueueCurrentPosition = clampEditableQueuePosition(queueIndexes, currentPosition);
+        return queueIndexes;
+    };
+
+    const resolveEditableQueueCurrentPosition = (queueIndexes: number[]): number => {
+        if (queueIndexes.length === 0) {
+            controllerState.editableQueueCurrentPosition = null;
+            return 0;
+        }
+
+        const storedPosition = controllerState.editableQueueCurrentPosition;
+        const currentTrackIndex = options.getCurrentTrackIndex();
+        const matchingPositions: number[] = [];
+        for (let position = 0; position < queueIndexes.length; position += 1) {
+            if (queueIndexes[position] === currentTrackIndex) {
+                matchingPositions.push(position);
+            }
+        }
+
+        if (matchingPositions.length > 0) {
+            let resolvedPosition = matchingPositions[0];
+            if (Number.isInteger(storedPosition)) {
+                const targetPosition = storedPosition as number;
+                for (const position of matchingPositions) {
+                    const currentDistance = Math.abs(position - targetPosition);
+                    const bestDistance = Math.abs(resolvedPosition - targetPosition);
+                    if (currentDistance < bestDistance) {
+                        resolvedPosition = position;
+                    }
+                }
+            }
+
+            controllerState.editableQueueCurrentPosition = resolvedPosition;
+            return resolvedPosition;
+        }
+
+        const resolvedPosition = clampEditableQueuePosition(queueIndexes, storedPosition);
+        controllerState.editableQueueCurrentPosition = resolvedPosition;
+        return resolvedPosition;
+    };
+
+    const updateEditableQueueCurrentPositionAfterRemoval = (removePosition: number, queueLength: number): void => {
+        if (!controllerState.editableQueueTrackIndexes) {
+            return;
+        }
+
+        if (queueLength <= 0) {
+            controllerState.editableQueueCurrentPosition = null;
+            return;
+        }
+
+        let nextPosition = clampEditableQueuePosition(controllerState.editableQueueTrackIndexes, controllerState.editableQueueCurrentPosition);
+        if (removePosition < nextPosition) {
+            nextPosition -= 1;
+        }
+
+        controllerState.editableQueueCurrentPosition = Math.max(0, Math.min(nextPosition, queueLength - 1));
+    };
+
+    const updateEditableQueueCurrentPositionAfterMove = (fromPosition: number, toPosition: number, queueLength: number): void => {
+        if (!controllerState.editableQueueTrackIndexes || queueLength <= 0) {
+            return;
+        }
+
+        let nextPosition = clampEditableQueuePosition(controllerState.editableQueueTrackIndexes, controllerState.editableQueueCurrentPosition);
+        if (fromPosition === nextPosition) {
+            nextPosition = toPosition;
+        } else if (fromPosition < nextPosition && toPosition >= nextPosition) {
+            nextPosition -= 1;
+        } else if (fromPosition > nextPosition && toPosition <= nextPosition) {
+            nextPosition += 1;
+        }
+
+        controllerState.editableQueueCurrentPosition = Math.max(0, Math.min(nextPosition, queueLength - 1));
+    };
+
+    const clearQueueDragClasses = (): void => {
+        playlistList.querySelectorAll('.playlist-row.is-dragging, .playlist-row.is-drop-target').forEach((row) => {
+            row.classList.remove('is-dragging', 'is-drop-target');
+        });
+    };
+
+    const updateQueueDragTargetClasses = (): void => {
+        clearQueueDragClasses();
+        if (!queueDragState) {
+            return;
+        }
+
+        const dragRow = playlistList.querySelector<HTMLElement>(`.playlist-row[data-playlist-position="${queueDragState.fromPosition}"]`);
+        dragRow?.classList.add('is-dragging');
+
+        const dropRow = playlistList.querySelector<HTMLElement>(`.playlist-row[data-playlist-position="${queueDragState.targetPosition}"]`);
+        dropRow?.classList.add('is-drop-target');
+    };
+
+    const updateQueueDragTargetFromPoint = (clientX: number, clientY: number): void => {
+        if (!queueDragState) {
+            return;
+        }
+
+        const hovered = document.elementFromPoint(clientX, clientY);
+        if (!(hovered instanceof Element)) {
+            return;
+        }
+
+        const row = hovered.closest('.playlist-row');
+        if (!(row instanceof HTMLElement) || !playlistList.contains(row)) {
+            return;
+        }
+
+        const targetPosition = Number(row.dataset.playlistPosition);
+        if (!Number.isInteger(targetPosition) || targetPosition === queueDragState.targetPosition) {
+            return;
+        }
+
+        queueDragState.targetPosition = targetPosition;
+        updateQueueDragTargetClasses();
+    };
+
+    const finalizeQueueDrag = (applyReorder: boolean): void => {
+        const dragState = queueDragState;
+        queueDragState = null;
+
+        if (!dragState) {
+            return;
+        }
+
+        clearQueueDragClasses();
+
+        if (applyReorder) {
+            const activeQueue = mutableCurrentSequence();
+            const { fromPosition, targetPosition } = dragState;
+            if (
+                Number.isInteger(fromPosition)
+                && Number.isInteger(targetPosition)
+                && fromPosition >= 0
+                && targetPosition >= 0
+                && fromPosition < activeQueue.length
+                && targetPosition < activeQueue.length
+                && fromPosition !== targetPosition
+            ) {
+                const [moved] = activeQueue.splice(fromPosition, 1);
+                activeQueue.splice(targetPosition, 0, moved);
+                updateEditableQueueCurrentPositionAfterMove(fromPosition, targetPosition, activeQueue.length);
+            }
+        }
+
+        const shouldRender = deferredRenderDuringQueueDrag || applyReorder;
+        deferredRenderDuringQueueDrag = false;
+        if (shouldRender && !playlistModal.hidden) {
+            renderPlaylist();
+        }
+    };
+
     const getPlaylistRowLabels = (
         trackIndex: number,
         cachedItemsByTrackIndex: Map<number, LoadedPlaylistCachedItem>,
@@ -617,11 +804,11 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.loadedPlaylistReadOnly = false;
         controllerState.loadedPlaylistHistoryItems = null;
         controllerState.loadedPlaylistCachedItems = sanitizedPlaylist.cachedItems || null;
-        controllerState.editableQueueTrackIndexes = null;
+        clearEditableQueueState();
         controllerState.selectedSource = 'playlist';
         controllerState.playbackSource = 'queue';
         controllerState.selectedFavoriteIndex = null;
-        dragFromPosition = null;
+        finalizeQueueDrag(false);
         clearPlaylistFilter();
         playlistList.scrollTop = 0;
         resetHydrationRequestState();
@@ -644,11 +831,11 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.loadedPlaylistReadOnly = true;
         controllerState.loadedPlaylistHistoryItems = sanitizedPlaylist.historyItems || [];
         controllerState.loadedPlaylistCachedItems = sanitizedPlaylist.cachedItems || null;
-        controllerState.editableQueueTrackIndexes = null;
+        clearEditableQueueState();
         controllerState.selectedSource = 'history';
         controllerState.playbackSource = 'queue';
         controllerState.selectedFavoriteIndex = null;
-        dragFromPosition = null;
+        finalizeQueueDrag(false);
         clearPlaylistFilter();
         playlistList.scrollTop = 0;
         resetHydrationRequestState();
@@ -679,11 +866,10 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
 
     const queueSequence = (): PlaylistSequence => {
         if (controllerState.editableQueueTrackIndexes && controllerState.editableQueueTrackIndexes.length > 0) {
-            const currentTrackIndex = options.getCurrentTrackIndex();
-            const currentPosition = controllerState.editableQueueTrackIndexes.indexOf(currentTrackIndex);
+            const currentPosition = resolveEditableQueueCurrentPosition(controllerState.editableQueueTrackIndexes);
             return {
                 indexes: controllerState.editableQueueTrackIndexes,
-                currentPosition: currentPosition >= 0 ? currentPosition : 0,
+                currentPosition,
             };
         }
 
@@ -1050,6 +1236,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         clearPlaylistFilter();
         playlistModal.classList.remove('is-visible');
         cancelHydration();
+        finalizeQueueDrag(false);
 
         if (playlistModalHideTimer !== undefined) {
             window.clearTimeout(playlistModalHideTimer);
@@ -1060,7 +1247,6 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             playlistModalHideTimer = undefined;
         }, playlistModalTransitionMs);
 
-        dragFromPosition = null;
     };
 
     const prefersReducedMotion = (): boolean => {
@@ -1143,6 +1329,11 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
     };
 
     const renderPlaylist = (animateViewSwitch = false, animateFilterResults = false): void => {
+        if (queueDragState && controllerState.selectedSource === 'queue') {
+            deferredRenderDuringQueueDrag = true;
+            return;
+        }
+
         const shouldAnimateDialog = animateViewSwitch;
         const previousDialogHeight = shouldAnimateDialog ? playlistDialog.getBoundingClientRect().height : 0;
         if (shouldAnimateDialog) {
@@ -1158,13 +1349,17 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
 
         const { indexes, currentPosition } = currentSequence();
         const currentTrackIndex = options.getCurrentTrackIndex();
-        const activePosition = indexes.indexOf(currentTrackIndex);
+        const activePosition = currentPosition >= 0
+            && currentPosition < indexes.length
+            && indexes[currentPosition] === currentTrackIndex
+            ? currentPosition
+            : indexes.indexOf(currentTrackIndex);
         const anchorPosition = activePosition >= 0 ? activePosition : currentPosition;
         const viewingPlaylist = controllerState.selectedSource !== 'queue' && hasLoadedPlaylist();
         const playlistVisibleWindow = viewingPlaylist ? getPlaylistVisibleWindow(indexes) : null;
         const start = viewingPlaylist
             ? (playlistVisibleWindow?.start || 0)
-            : Math.max(0, anchorPosition);
+            : Math.max(0, anchorPosition - queueVisiblePreviousCount);
         const end = viewingPlaylist
             ? (playlistVisibleWindow?.end || 0)
             : Math.min(indexes.length, anchorPosition + queueVisibleAheadCount + 1);
@@ -1203,8 +1398,9 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
 
             visibleRows = nextVisibleRows;
         } else {
+            const hydrationStart = Math.max(0, start - queueHydrationLookbehind);
             const hydrationEnd = Math.min(indexes.length, end + queueHydrationLookahead);
-            requestTrackMetadataHydration(indexes.slice(start, hydrationEnd));
+            requestTrackMetadataHydration(indexes.slice(hydrationStart, hydrationEnd));
 
             const nextVisibleRows: RenderablePlaylistRow[] = [];
             for (let position = start; position < indexes.length && nextVisibleRows.length < end - start; position += 1) {
@@ -1237,6 +1433,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         const rows = visibleRows.map(({ trackIndex, actualPosition }) => {
             const activeClass = trackIndex === currentTrackIndex ? ' is-active' : '';
             const isActiveTrack = trackIndex === currentTrackIndex;
+            const disableQueueDragHandle = controllerState.selectedSource === 'queue' && isActiveTrack;
             const prefix = isActiveTrack
                 ? playlistPrefixIcon('active')
                 : (activePosition >= 0 && actualPosition < activePosition ? playlistPrefixIcon('before') : playlistPrefixIcon('after'));
@@ -1251,8 +1448,8 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         </li>`;
             }
 
-            return `<li class="playlist-row" draggable="true" data-playlist-position="${actualPosition}">
-            <button class="playlist-drag-handle" type="button" aria-label="Drag track" title="Drag to reorder">${playlistDragIcon}</button>
+            return `<li class="playlist-row" data-playlist-position="${actualPosition}">
+            <button class="playlist-drag-handle" type="button" ${disableQueueDragHandle ? 'disabled aria-disabled="true" title="Cannot move the currently playing track"' : 'title="Drag to reorder"'} aria-label="${disableQueueDragHandle ? 'Currently playing track cannot be reordered' : 'Drag track'}">${playlistDragIcon}</button>
             <span class="playlist-position-indicator">#${actualPosition + 1}</span>
             <button class="playlist-item${activeClass}" data-playlist-track-index="${trackIndex}" data-playlist-position="${actualPosition}"><span class="playlist-item-main"><span class="playlist-item-prefix">${prefix}</span><span class="playlist-item-label">${label}</span></span><span class="playlist-item-sub">${secondary}</span></button>
             <button class="playlist-remove" type="button" data-playlist-remove-position="${actualPosition}" aria-label="Remove track" title="Remove track">${playlistRemoveIcon}</button>
@@ -1279,6 +1476,11 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         let scheduled = false;
 
         return (): void => {
+            if (queueDragState && controllerState.selectedSource === 'queue') {
+                deferredRenderDuringQueueDrag = true;
+                return;
+            }
+
             if (scheduled) {
                 return;
             }
@@ -1401,7 +1603,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             return;
         }
 
-        const start = Math.max(0, currentPosition);
+        const start = Math.max(0, currentPosition - queueVisiblePreviousCount - queueHydrationLookbehind);
         const end = Math.min(indexes.length, currentPosition + queueVisibleAheadCount + 1 + queueHydrationLookahead);
         requestTrackMetadataHydration(indexes.slice(start, end));
     };
@@ -1452,8 +1654,8 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             return controllerState.editableQueueTrackIndexes;
         }
 
-        controllerState.editableQueueTrackIndexes = queueSequence().indexes.slice();
-        return controllerState.editableQueueTrackIndexes;
+        const sequence = queueSequence();
+        return setEditableQueueState(sequence.indexes.slice(), sequence.currentPosition);
     };
 
     const insertTrackIndexes = (queue: number[], insertAt: number, trackIndexes: number[]): void => {
@@ -1580,10 +1782,11 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             }
         }
 
-        const queueIndexes = queueSequence().indexes;
+        const queue = queueSequence();
+        const queueIndexes = queue.indexes;
         if ((controllerState.editableQueueTrackIndexes && controllerState.editableQueueTrackIndexes.length > 0) || hasLoadedPlaylist()) {
-            const currentPosition = queueIndexes.indexOf(currentTrackIndex);
-            if (currentPosition < 0) {
+            const currentPosition = queue.currentPosition;
+            if (currentPosition < 0 || currentPosition >= queueIndexes.length) {
                 return queueIndexes[0];
             }
 
@@ -1592,12 +1795,15 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
 	                return undefined;
 	            }
 
-                controllerState.editableQueueTrackIndexes = null;
+                clearEditableQueueState();
                 scheduleRender();
                 return undefined;
             }
 
             const nextPosition = (currentPosition + direction + queueIndexes.length) % queueIndexes.length;
+            if (mutateState && controllerState.editableQueueTrackIndexes) {
+                controllerState.editableQueueCurrentPosition = nextPosition;
+            }
             return queueIndexes[nextPosition];
         }
 
@@ -1613,13 +1819,13 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
     };
 
     const clearEditableQueue = (): void => {
-        controllerState.editableQueueTrackIndexes = null;
+        clearEditableQueueState();
         scheduleRender();
     };
 
     const activatePlaybackQueueSource = (): void => {
         controllerState.playbackSource = 'queue';
-        controllerState.editableQueueTrackIndexes = null;
+        clearEditableQueueState();
         scheduleRender();
     };
 
@@ -1630,12 +1836,12 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.loadedPlaylistReadOnly = false;
         controllerState.loadedPlaylistHistoryItems = null;
         controllerState.loadedPlaylistCachedItems = null;
-        controllerState.editableQueueTrackIndexes = null;
+        clearEditableQueueState();
         controllerState.selectedSource = 'queue';
         controllerState.selectedFavoriteIndex = null;
         controllerState.playbackSource = 'queue';
         cancelHydration();
-        dragFromPosition = null;
+        finalizeQueueDrag(false);
         clearPlaylistFilter();
         scheduleRender();
     };
@@ -1722,7 +1928,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.loadedPlaylistCachedItems = null;
         controllerState.selectedSource = 'playlist';
         controllerState.playbackSource = 'queue';
-        controllerState.editableQueueTrackIndexes = null;
+        clearEditableQueueState();
         controllerState.selectedFavoriteIndex = null;
         clearPlaylistFilter();
         playlistList.scrollTop = 0;
@@ -1750,7 +1956,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         controllerState.loadedPlaylistCachedItems = sanitizedPlaylist.cachedItems || null;
         controllerState.selectedSource = 'playlist';
         controllerState.playbackSource = 'queue';
-        dragFromPosition = null;
+        finalizeQueueDrag(false);
         clearPlaylistFilter();
         playlistList.scrollTop = 0;
         resetHydrationRequestState();
@@ -1811,7 +2017,7 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         if (controllerState.selectedSource !== 'queue' && hasLoadedPlaylist()) {
             const playlistSequence = loadedPlaylistSequence();
             if (playlistSequence) {
-                controllerState.editableQueueTrackIndexes = playlistSequence.indexes.slice();
+                setEditableQueueState(playlistSequence.indexes.slice(), playlistSequence.currentPosition);
             }
             controllerState.playbackSource = 'queue';
             return;
@@ -2071,7 +2277,9 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             }
 
             if (controllerState.editableQueueTrackIndexes && controllerState.editableQueueTrackIndexes.length === 0) {
-                controllerState.editableQueueTrackIndexes = null;
+                clearEditableQueueState();
+            } else {
+                updateEditableQueueCurrentPositionAfterRemoval(removePosition, activeQueue.length);
             }
 
             renderPlaylist();
@@ -2088,6 +2296,11 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             return;
         }
 
+        const chosenPosition = Number(button.dataset.playlistPosition);
+        if (controllerState.editableQueueTrackIndexes && Number.isInteger(chosenPosition)) {
+            controllerState.editableQueueCurrentPosition = clampEditableQueuePosition(controllerState.editableQueueTrackIndexes, chosenPosition);
+        }
+
         commitPlaybackSourceFromCurrentView();
         void options.onTrackChosen(trackIndex, {
             source: controllerState.selectedSource,
@@ -2097,8 +2310,12 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
         });
     });
 
-    playlistList.addEventListener('dragstart', (event) => {
+    playlistList.addEventListener('pointerdown', (event) => {
         if (isViewingReadOnlyPlaylist()) {
+            return;
+        }
+
+        if (event.button !== 0) {
             return;
         }
 
@@ -2112,6 +2329,15 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             return;
         }
 
+        const dragHandle = target.closest('.playlist-drag-handle');
+        if (!(dragHandle instanceof HTMLButtonElement)) {
+            return;
+        }
+
+        if (dragHandle.disabled) {
+            return;
+        }
+
         const row = target.closest('.playlist-row');
         if (!(row instanceof HTMLElement)) {
             return;
@@ -2122,82 +2348,43 @@ export const createPlaylistController = (options: PlaylistControllerOptions) => 
             return;
         }
 
-        dragFromPosition = fromPosition;
-        row.classList.add('is-dragging');
-
-        if (event.dataTransfer) {
-            event.dataTransfer.effectAllowed = 'move';
-            event.dataTransfer.setData('text/plain', String(fromPosition));
+        event.preventDefault();
+        deferredRenderDuringQueueDrag = false;
+        queueDragState = {
+            fromPosition,
+            targetPosition: fromPosition,
+            pointerId: event.pointerId,
+        };
+        if (typeof dragHandle.setPointerCapture === 'function') {
+            dragHandle.setPointerCapture(event.pointerId);
         }
+        updateQueueDragTargetClasses();
     });
 
-    playlistList.addEventListener('dragend', () => {
-        dragFromPosition = null;
-        const rows = playlistList.querySelectorAll('.playlist-row.is-dragging');
-        rows.forEach((row) => row.classList.remove('is-dragging'));
-    });
-
-    playlistList.addEventListener('dragover', (event) => {
-        if (isViewingReadOnlyPlaylist()) {
-            return;
-        }
-
-        const activeQueue = currentSequence().indexes;
-        if (activeQueue.length === 0) {
-            return;
-        }
-
-        const target = event.target;
-        if (!(target instanceof Element)) {
-            return;
-        }
-
-        const row = target.closest('.playlist-row');
-        if (!(row instanceof HTMLElement)) {
+    window.addEventListener('pointermove', (event) => {
+        if (!queueDragState || event.pointerId !== queueDragState.pointerId) {
             return;
         }
 
         event.preventDefault();
-        if (event.dataTransfer) {
-            event.dataTransfer.dropEffect = 'move';
-        }
+        updateQueueDragTargetFromPoint(event.clientX, event.clientY);
     });
 
-    playlistList.addEventListener('drop', (event) => {
-        if (isViewingReadOnlyPlaylist()) {
-            return;
-        }
-
-        const activeQueue = mutableCurrentSequence();
-        if (activeQueue.length === 0) {
-            return;
-        }
-
-        const target = event.target;
-        if (!(target instanceof Element)) {
-            return;
-        }
-
-        const row = target.closest('.playlist-row');
-        if (!(row instanceof HTMLElement)) {
+    window.addEventListener('pointerup', (event) => {
+        if (!queueDragState || event.pointerId !== queueDragState.pointerId) {
             return;
         }
 
         event.preventDefault();
+        finalizeQueueDrag(true);
+    });
 
-        const toPosition = Number(row.dataset.playlistPosition);
-        const fromPosition = dragFromPosition ?? Number(event.dataTransfer?.getData('text/plain'));
-        if (!Number.isInteger(fromPosition) || !Number.isInteger(toPosition) || fromPosition === toPosition) {
+    window.addEventListener('pointercancel', (event) => {
+        if (!queueDragState || event.pointerId !== queueDragState.pointerId) {
             return;
         }
 
-        if (fromPosition < 0 || toPosition < 0 || fromPosition >= activeQueue.length || toPosition >= activeQueue.length) {
-            return;
-        }
-
-        const [moved] = activeQueue.splice(fromPosition, 1);
-        activeQueue.splice(toPosition, 0, moved);
-        renderPlaylist();
+        finalizeQueueDrag(false);
     });
 
     return {


### PR DESCRIPTION
Replace the queue reorder interaction with pointer-based dragging, preserve the active shuffle cursor, and restore the previous/next queue window around the current track. Stabilize the progressive remote decode regression test by asserting behavior directly instead of relying on a brittle timing threshold. Validated with the full npm run validate:ci pipeline on Windows.