### PR TITLE
Add MusicBrainz MBID search functionality and enhance Connection Explorer interactions

### DIFF
--- a/app_library_queries.go
+++ b/app_library_queries.go
@@ -381,6 +381,7 @@ func (a *App) SearchLibrary(query string, offset int, limit int) LibrarySearchPa
 		}
 
 		musicBrainzTagQuery, hasMusicBrainzTagQuery := parseMusicBrainzTagSearchQuery(query)
+		musicBrainzEntityIDQuery, hasMusicBrainzEntityIDQuery := parseMusicBrainzEntityIDSearchQuery(query)
 
 		if searchCanceled() {
 			a.logRescanEvent("SearchLibrary CANCELED before lock: query=%q offset=%d", logQuery, offset)
@@ -415,6 +416,9 @@ func (a *App) SearchLibrary(query string, offset int, limit int) LibrarySearchPa
 		if hasMusicBrainzTagQuery {
 			entries = a.buildMusicBrainzTagSearchResultsLocked(musicBrainzTagQuery)
 			mode = "musicbrainz-tags"
+		} else if hasMusicBrainzEntityIDQuery {
+			entries = a.buildMusicBrainzEntityIDSearchResultsLocked(musicBrainzEntityIDQuery)
+			mode = "musicbrainz-mbid"
 		} else if a.isLibrarySearchIndexReadyLocked() {
 			var derivedMode string
 			entries, derivedMode, canceled = a.buildSearchResultsLocked(normalizedQuery, searchCanceled)

--- a/app_library_queries_additional_test.go
+++ b/app_library_queries_additional_test.go
@@ -39,14 +39,14 @@ func newIndexedLibraryAppForTests(t *testing.T) (*App, libraryTestFixture) {
 	app.libraryScan.ImageFiles = []LibraryIndexedFile{app.imageByPath[fixture.coverOne], app.imageByPath[fixture.folderCoverOne], app.imageByPath[fixture.imageTwo]}
 	app.libraryScan.CoverPathByFolder[strings.ToLower(app.imageByPath[fixture.coverOne].FolderPath)] = fixture.coverOne
 
-	indexData := buildLibraryDerivedIndexData(app.libraryScan.TrackFiles, app.libraryScan.TextFiles, app.libraryScan.ImageFiles)
-	app.folderEntriesByFolder = indexData.folderEntriesByFolder
-	app.folderChildPathsByFolder = indexData.folderChildPathsByFolder
-	app.trackFilesByFolder = indexData.trackFilesByFolder
-	app.searchFolderEntries = indexData.searchFolderEntries
-	app.searchTrackEntries = indexData.searchTrackEntries
-	app.searchTextEntries = indexData.searchTextEntries
-	app.searchImageEntries = indexData.searchImageEntries
+	updatedIndexData := buildLibraryDerivedIndexData(app.libraryScan.TrackFiles, app.libraryScan.TextFiles, app.libraryScan.ImageFiles)
+	app.folderEntriesByFolder = updatedIndexData.folderEntriesByFolder
+	app.folderChildPathsByFolder = updatedIndexData.folderChildPathsByFolder
+	app.trackFilesByFolder = updatedIndexData.trackFilesByFolder
+	app.searchFolderEntries = updatedIndexData.searchFolderEntries
+	app.searchTrackEntries = updatedIndexData.searchTrackEntries
+	app.searchTextEntries = updatedIndexData.searchTextEntries
+	app.searchImageEntries = updatedIndexData.searchImageEntries
 	app.libraryDerivedIndexDirty = false
 	app.libraryDerivedIndexBuilding = false
 
@@ -322,10 +322,40 @@ func TestLibraryQueryFallbackPagingAndMusicBrainzTagSearch(t *testing.T) {
 	app.musicBrainzTagStoreLoaded = true
 	app.musicBrainzTagStore = newMusicBrainzTagDatabaseStore()
 
+	otherAlbumTrack := filepath.Join(fixture.rootOne, "Artist One", "Album Two", "02 Bonus.flac")
+	writeTestFile(t, otherAlbumTrack, "bonus track")
+	for _, root := range app.activeLibraryRoots {
+		if !pathWithinRoot(root.Path, otherAlbumTrack) {
+			continue
+		}
+
+		app.addOrUpdateIndexedFile(root, otherAlbumTrack, filepath.Base(otherAlbumTrack))
+		break
+	}
+	app.libraryScan.TrackFiles = append(app.libraryScan.TrackFiles, app.trackByPath[otherAlbumTrack])
+	updatedIndexData := buildLibraryDerivedIndexData(app.libraryScan.TrackFiles, app.libraryScan.TextFiles, app.libraryScan.ImageFiles)
+	app.folderEntriesByFolder = updatedIndexData.folderEntriesByFolder
+	app.folderChildPathsByFolder = updatedIndexData.folderChildPathsByFolder
+	app.trackFilesByFolder = updatedIndexData.trackFilesByFolder
+	app.searchFolderEntries = updatedIndexData.searchFolderEntries
+	app.searchTrackEntries = updatedIndexData.searchTrackEntries
+	app.searchTextEntries = updatedIndexData.searchTextEntries
+	app.searchImageEntries = updatedIndexData.searchImageEntries
+
+	const recordingID = "33333333-3333-4333-8333-333333333333"
 	const releaseID = "11111111-1111-4111-8111-111111111111"
 	const artistID = "22222222-2222-4222-8222-222222222222"
+	const albumArtistID = "44444444-4444-4444-8444-444444444444"
 	releaseKey := musicBrainzTagEntityKey("release", releaseID)
 	artistKey := musicBrainzTagEntityKey("artist", artistID)
+	app.musicBrainzTagStore.Tracks[fixture.trackOne] = musicBrainzTagTrackRecord{
+		RecordingID:       recordingID,
+		ReleaseID:         releaseID,
+		ArtistIDs:         []string{artistID},
+		AlbumArtistIDs:    []string{albumArtistID},
+		ReleaseFolderPath: "Library One/Artist One/Album One",
+		ArtistFolderPaths: []string{"Library One/Artist One"},
+	}
 	app.musicBrainzTagStore.Entities[releaseKey] = musicBrainzTagEntityRecord{EntityType: "release", MBID: releaseID}
 	app.musicBrainzTagStore.Entities[artistKey] = musicBrainzTagEntityRecord{EntityType: "artist", MBID: artistID}
 	app.musicBrainzTagEntityKeysByTag = map[string]map[string]struct{}{
@@ -382,6 +412,44 @@ func TestLibraryQueryFallbackPagingAndMusicBrainzTagSearch(t *testing.T) {
 		t.Fatalf("SearchLibrary(mbtag) artist folder tag highlight = true, want false: %#v", tagSearch.Entries)
 	}
 
+	artistMBIDSearch := app.SearchLibrary("mbid-artist:"+artistID, 0, 20)
+	if !hasBrowserEntry(artistMBIDSearch.Entries, "folder", "Library One/Artist One") {
+		t.Fatalf("SearchLibrary(mbid-artist) missing artist folder: %#v", artistMBIDSearch.Entries)
+	}
+	if !hasBrowserEntry(artistMBIDSearch.Entries, "folder", "Library One/Artist One/Album One") {
+		t.Fatalf("SearchLibrary(mbid-artist) missing album folder: %#v", artistMBIDSearch.Entries)
+	}
+	if !hasBrowserEntry(artistMBIDSearch.Entries, "track", fixture.trackOne) {
+		t.Fatalf("SearchLibrary(mbid-artist) missing track %q: %#v", fixture.trackOne, artistMBIDSearch.Entries)
+	}
+	if hasBrowserEntry(artistMBIDSearch.Entries, "folder", "Library One/Artist One/Album Two") {
+		t.Fatalf("SearchLibrary(mbid-artist) unexpectedly included unmatched album folder: %#v", artistMBIDSearch.Entries)
+	}
+
+	albumArtistMBIDSearch := app.SearchLibrary("mbid-artist:"+albumArtistID, 0, 20)
+	if albumArtistMBIDSearch.TotalEntries != 0 || len(albumArtistMBIDSearch.Entries) != 0 {
+		t.Fatalf("SearchLibrary(mbid-artist album artist) = %#v, want empty search results", albumArtistMBIDSearch)
+	}
+
+	releaseMBIDSearch := app.SearchLibrary("mbid-release:"+releaseID, 0, 20)
+	if !hasBrowserEntry(releaseMBIDSearch.Entries, "folder", "Library One/Artist One/Album One") {
+		t.Fatalf("SearchLibrary(mbid-release) missing album folder: %#v", releaseMBIDSearch.Entries)
+	}
+	if !hasBrowserEntry(releaseMBIDSearch.Entries, "track", fixture.trackOne) {
+		t.Fatalf("SearchLibrary(mbid-release) missing track %q: %#v", fixture.trackOne, releaseMBIDSearch.Entries)
+	}
+	if hasBrowserEntry(releaseMBIDSearch.Entries, "folder", "Library One/Artist One") {
+		t.Fatalf("SearchLibrary(mbid-release) unexpectedly included artist folder: %#v", releaseMBIDSearch.Entries)
+	}
+
+	recordingMBIDSearch := app.SearchLibrary("mbid-recording:"+recordingID, 0, 20)
+	if !hasBrowserEntry(recordingMBIDSearch.Entries, "track", fixture.trackOne) {
+		t.Fatalf("SearchLibrary(mbid-recording) missing track %q: %#v", fixture.trackOne, recordingMBIDSearch.Entries)
+	}
+	if hasBrowserEntry(recordingMBIDSearch.Entries, "track", fixture.trackTwo) {
+		t.Fatalf("SearchLibrary(mbid-recording) unexpectedly included track %q: %#v", fixture.trackTwo, recordingMBIDSearch.Entries)
+	}
+
 	app.musicBrainzTagReleaseFoldersByID[releaseID] = map[string]struct{}{
 		"Library One/Artist One/01 Missing Album": {},
 		"Library One/Artist One/Album One":        {},
@@ -401,6 +469,11 @@ func TestLibraryQueryFallbackPagingAndMusicBrainzTagSearch(t *testing.T) {
 	emptyTagSearch := app.SearchLibrary("mbtag:", 0, 20)
 	if emptyTagSearch.TotalEntries != 0 || len(emptyTagSearch.Entries) != 0 {
 		t.Fatalf("SearchLibrary(empty mbtag) = %#v, want empty search results", emptyTagSearch)
+	}
+
+	emptyArtistMBIDSearch := app.SearchLibrary("mbid-artist:", 0, 20)
+	if emptyArtistMBIDSearch.TotalEntries != 0 || len(emptyArtistMBIDSearch.Entries) != 0 {
+		t.Fatalf("SearchLibrary(empty mbid-artist) = %#v, want empty search results", emptyArtistMBIDSearch)
 	}
 }
 

--- a/frontend/src/app-core-services-runtime.ts
+++ b/frontend/src/app-core-services-runtime.ts
@@ -358,7 +358,7 @@ export const createAppCoreServicesRuntime = (context: AppCoreServicesRuntimeCont
         context.libraryController().navigateToFolder(cleanFolderPath);
     };
 
-    const openLibrarySearch = (query: string): void => {
+    const openLibrarySearch = (query: string, options?: { expandFilteredFolders?: boolean }): void => {
         const cleanQuery = query.trim();
         if (cleanQuery === '') {
             return;
@@ -371,7 +371,7 @@ export const createAppCoreServicesRuntime = (context: AppCoreServicesRuntimeCont
             libraryController.setSidebarOpen(true);
         }
 
-        libraryController.startLibrarySearch(cleanQuery);
+        libraryController.startLibrarySearch(cleanQuery, options);
         context.librarySearch.focus({ preventScroll: true });
         context.librarySearch.select();
     };
@@ -708,6 +708,7 @@ export const createAppCoreServicesRuntime = (context: AppCoreServicesRuntimeCont
         listenBrainzController,
         sidebarController,
         socialController,
+        openLibrarySearch,
         playbackSequencingService,
         playbackStateService,
         refreshListenBrainzFeedbackForCurrentTrack,

--- a/frontend/src/app-runtime-scope.ts
+++ b/frontend/src/app-runtime-scope.ts
@@ -107,6 +107,7 @@ type ReturnedRuntimeMethods = {
     resetArtistInfoPanel: () => void;
     hasLastFmScrobbling: () => boolean;
     hasListenBrainzScrobbling: () => boolean;
+    openLibrarySearch: (query: string, options?: { expandFilteredFolders?: boolean }) => void;
     refreshListenBrainzFeedbackForCurrentTrack: (force?: boolean) => Promise<void>;
     resetListenBrainzFeedbackState: () => void;
     submitListenBrainzFeedbackForTrack: (trackIndex: number, score: ListenBrainzFeedbackScore) => Promise<void>;

--- a/frontend/src/components/media-controls-exploration.test.ts
+++ b/frontend/src/components/media-controls-exploration.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+    browserOpenUrlMock,
+    eventsOnMock,
+    lookupMusicBrainzExplorationMock,
+} = vi.hoisted(() => ({
+    browserOpenUrlMock: vi.fn(),
+    eventsOnMock: vi.fn(() => vi.fn()),
+    lookupMusicBrainzExplorationMock: vi.fn(),
+}));
+
+vi.mock('../../wailsjs/runtime/runtime', () => ({
+    BrowserOpenURL: browserOpenUrlMock,
+    EventsOn: eventsOnMock,
+}));
+
+vi.mock('../utils/musicbrainz-entity-helpers', () => ({
+    lookupMusicBrainzExploration: lookupMusicBrainzExplorationMock,
+    musicBrainzMBIDSearchQuery: (entityType: string, mbid: string) => {
+        const normalizedEntityType = entityType.trim().toLowerCase();
+        const normalizedMBID = mbid.trim().toLowerCase();
+        if (normalizedEntityType === 'artist') {
+            return `mbid-artist:${normalizedMBID}`;
+        }
+        if (normalizedEntityType === 'release') {
+            return `mbid-release:${normalizedMBID}`;
+        }
+        if (normalizedEntityType === 'recording') {
+            return `mbid-recording:${normalizedMBID}`;
+        }
+        return '';
+    },
+}));
+
+import type { Track } from '../types/app-types';
+import { setupExplorationButton, updateExplorationButton } from './media-controls-exploration';
+
+const flushPromises = async (): Promise<void> => {
+    for (let index = 0; index < 4; index += 1) {
+        await Promise.resolve();
+    }
+};
+
+const createTrack = (): Track => ({
+    title: 'Track',
+    name: 'Track',
+    path: '/music/track.flac',
+    relativePath: 'Library/Artist/Album/Track.flac',
+    folderPath: 'Library/Artist/Album',
+    rootPath: '/music',
+    rootName: 'Library',
+    displayTitle: 'Track',
+    displayAlbum: 'Album',
+    displayArtist: 'Artist',
+    displayTrackNumber: '1',
+    displayTrackTotal: '1',
+    displayTechnical: '',
+    displayLyrics: '',
+    tagsResolved: true,
+    mbMetadataResolved: false,
+    technicalDetails: {},
+    allFileTags: {},
+    mbIds: {
+        artistId: '5e9450ca-77d5-4f64-a385-f453cfe98b24',
+        releaseId: '11111111-1111-4111-8111-111111111111',
+        recordingId: '22222222-2222-4222-8222-222222222222',
+    },
+    artistMbids: ['5e9450ca-77d5-4f64-a385-f453cfe98b24'],
+    mbArtistCredits: [{ name: 'Artist', artistId: '5e9450ca-77d5-4f64-a385-f453cfe98b24', joinPhrase: '' }],
+});
+
+describe('media controls exploration', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        document.body.innerHTML = '<button id="exploration-btn" type="button"></button>';
+        vi.stubGlobal('requestAnimationFrame', ((callback: FrameRequestCallback): number => {
+            callback(0);
+            return 0;
+        }) as typeof requestAnimationFrame);
+    });
+
+    it('closes the modal and opens MBID searches when artist or release nodes are clicked', async () => {
+        const track = createTrack();
+        const openLibrarySearch = vi.fn();
+
+        lookupMusicBrainzExplorationMock.mockResolvedValue({
+            found: true,
+            title: 'Connection Explorer',
+            summary: 'Connections',
+            warnings: [],
+            nodes: [
+                {
+                    id: 'artist:1',
+                    entityType: 'artist',
+                    kind: 'artist',
+                    mbid: '5e9450ca-77d5-4f64-a385-f453cfe98b24',
+                    label: 'Artist',
+                    subtitle: 'Artist',
+                    accent: '#ffffff',
+                    emphasis: 2,
+                    url: 'https://musicbrainz.org/artist/5e9450ca-77d5-4f64-a385-f453cfe98b24',
+                },
+                {
+                    id: 'release:1',
+                    entityType: 'release',
+                    kind: 'release',
+                    mbid: '11111111-1111-4111-8111-111111111111',
+                    label: 'Release',
+                    subtitle: 'Release',
+                    accent: '#ffffff',
+                    emphasis: 2,
+                    url: 'https://musicbrainz.org/release/11111111-1111-4111-8111-111111111111',
+                },
+            ],
+            edges: [],
+        });
+
+        setupExplorationButton(document, {
+            getActiveTrack: () => track,
+            openLibrarySearch,
+        });
+        updateExplorationButton(document, track);
+
+        const button = document.querySelector('#exploration-btn') as HTMLButtonElement;
+        button.click();
+        await flushPromises();
+
+        const modal = document.getElementById('exploration-modal') as HTMLDivElement;
+        expect(modal.hidden).toBe(false);
+
+        const artistNode = modal.querySelector('[data-node-id="artist:1"]') as SVGGElement;
+        artistNode.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(openLibrarySearch).toHaveBeenCalledWith(
+            'mbid-artist:5e9450ca-77d5-4f64-a385-f453cfe98b24',
+            { expandFilteredFolders: true },
+        );
+        vi.runOnlyPendingTimers();
+        expect(modal.hidden).toBe(true);
+
+        openLibrarySearch.mockClear();
+        button.click();
+        await flushPromises();
+
+        const reopenedModal = document.getElementById('exploration-modal') as HTMLDivElement;
+        const releaseNode = reopenedModal.querySelector('[data-node-id="release:1"]') as SVGGElement;
+        releaseNode.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(openLibrarySearch).toHaveBeenCalledWith(
+            'mbid-release:11111111-1111-4111-8111-111111111111',
+            { expandFilteredFolders: true },
+        );
+        vi.runOnlyPendingTimers();
+        expect(reopenedModal.hidden).toBe(true);
+        expect(browserOpenUrlMock).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/components/media-controls-exploration.ts
+++ b/frontend/src/components/media-controls-exploration.ts
@@ -1,11 +1,12 @@
-import type { MusicBrainzExplorationGraph, Track } from '../types/app-types';
-import { lookupMusicBrainzExploration } from '../utils/musicbrainz-entity-helpers';
+import type { MusicBrainzExplorationGraph, MusicBrainzExplorationNode, Track } from '../types/app-types';
+import { lookupMusicBrainzExploration, musicBrainzMBIDSearchQuery } from '../utils/musicbrainz-entity-helpers';
 import { renderExplorationGraph } from './overlays/exploration-graph';
 import { getExplorationModalElements, renderExplorationModal } from './overlays/exploration-modal';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
 
 type ExplorationButtonOptions = {
     getActiveTrack: () => Track | undefined;
+    openLibrarySearch?: (query: string, options?: { expandFilteredFolders?: boolean }) => void;
 };
 
 type ExplorationProgress = {
@@ -143,7 +144,11 @@ const renderExplorationMessage = (content: HTMLElement, className: string, messa
     content.replaceChildren(status);
 };
 
-const renderExplorationData = (content: HTMLElement, graph: MusicBrainzExplorationGraph): void => {
+const renderExplorationData = (
+    content: HTMLElement,
+    graph: MusicBrainzExplorationGraph,
+    onNodeActivated?: (node: MusicBrainzExplorationNode) => void,
+): void => {
     destroyActiveExplorationGraph();
 
     if (!graph.found || graph.nodes.length === 0) {
@@ -185,7 +190,7 @@ const renderExplorationData = (content: HTMLElement, graph: MusicBrainzExplorati
     graphHost.className = 'exploration-graph';
 
     content.replaceChildren(meta, graphHost);
-    activeExplorationGraph = renderExplorationGraph(graphHost, graph);
+    activeExplorationGraph = renderExplorationGraph(graphHost, graph, { onNodeActivated });
 };
 
 const ensureExplorationModal = (): HTMLDivElement | null => {
@@ -211,7 +216,10 @@ const closeExplorationModal = (modal: HTMLDivElement, content: HTMLElement, titl
     }, 200);
 };
 
-const openExplorationModal = async (track: Track): Promise<void> => {
+const openExplorationModal = async (
+    track: Track,
+    openLibrarySearch?: (query: string, options?: { expandFilteredFolders?: boolean }) => void,
+): Promise<void> => {
     const modal = ensureExplorationModal();
     if (!modal) {
         return;
@@ -239,7 +247,15 @@ const openExplorationModal = async (track: Track): Promise<void> => {
     const cached = explorationCache.get(cacheKey);
     if (cached) {
         activeExplorationRequestId = null;
-        renderExplorationData(explorationContent, cached);
+        renderExplorationData(explorationContent, cached, (node) => {
+            const query = musicBrainzMBIDSearchQuery(node.entityType, node.mbid);
+            if (query === '' || !openLibrarySearch) {
+                return;
+            }
+
+            closeExplorationModal(modal, explorationContent, explorationTitle);
+            openLibrarySearch(query, { expandFilteredFolders: true });
+        });
         return;
     }
 
@@ -252,7 +268,15 @@ const openExplorationModal = async (track: Track): Promise<void> => {
 
     activeExplorationRequestId = null;
     explorationCache.set(cacheKey, graph);
-    renderExplorationData(explorationContent, graph);
+    renderExplorationData(explorationContent, graph, (node) => {
+        const query = musicBrainzMBIDSearchQuery(node.entityType, node.mbid);
+        if (query === '' || !openLibrarySearch) {
+            return;
+        }
+
+        closeExplorationModal(modal, explorationContent, explorationTitle);
+        openLibrarySearch(query, { expandFilteredFolders: true });
+    });
 };
 
 export function setupExplorationButton(root: ParentNode, options: ExplorationButtonOptions) {
@@ -272,7 +296,7 @@ export function setupExplorationButton(root: ParentNode, options: ExplorationBut
             return;
         }
 
-        void openExplorationModal(activeTrack);
+        void openExplorationModal(activeTrack, options.openLibrarySearch);
     });
 }
 

--- a/frontend/src/components/overlays/exploration-graph.test.ts
+++ b/frontend/src/components/overlays/exploration-graph.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../wailsjs/runtime/runtime', () => ({
+    BrowserOpenURL: vi.fn(),
+}));
+
+import { renderExplorationGraph } from './exploration-graph';
+
+type AnimationFrameQueue = Map<number, FrameRequestCallback>;
+
+const createGraph = () => ({
+    found: true,
+    title: 'Connection Explorer',
+    summary: 'Connections',
+    warnings: [],
+    nodes: [
+        {
+            id: 'artist:1',
+            entityType: 'artist',
+            kind: 'artist',
+            mbid: '5e9450ca-77d5-4f64-a385-f453cfe98b24',
+            label: 'Artist',
+            subtitle: 'Artist',
+            accent: '#ffffff',
+            emphasis: 2,
+            url: 'https://musicbrainz.org/artist/5e9450ca-77d5-4f64-a385-f453cfe98b24',
+        },
+        {
+            id: 'release:1',
+            entityType: 'release',
+            kind: 'release',
+            mbid: '11111111-1111-4111-8111-111111111111',
+            label: 'Release',
+            subtitle: 'Release',
+            accent: '#ffffff',
+            emphasis: 2,
+            url: 'https://musicbrainz.org/release/11111111-1111-4111-8111-111111111111',
+        },
+    ],
+    edges: [
+        {
+            id: 'edge:1',
+            sourceId: 'artist:1',
+            targetId: 'release:1',
+            kind: 'artist-release',
+            label: 'released',
+        },
+    ],
+});
+
+describe('exploration graph', () => {
+    let rafQueue: AnimationFrameQueue;
+    let nextAnimationFrameId: number;
+
+    const extractScale = (transform: string | null): number => {
+        const match = transform?.match(/scale\(([^)]+)\)/);
+        return match ? Number(match[1]) : Number.NaN;
+    };
+
+    const flushAnimationFrame = (timestamp: number): void => {
+        const queuedFrames = Array.from(rafQueue.values());
+        rafQueue.clear();
+        for (const callback of queuedFrames) {
+            callback(timestamp);
+        }
+    };
+
+    beforeEach(() => {
+        rafQueue = new Map();
+        nextAnimationFrameId = 0;
+        vi.clearAllMocks();
+        document.body.innerHTML = '<div id="graph-host"></div>';
+        vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback): number => {
+            nextAnimationFrameId += 1;
+            rafQueue.set(nextAnimationFrameId, callback);
+            return nextAnimationFrameId;
+        }) as typeof requestAnimationFrame);
+        vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => {
+            rafQueue.delete(id);
+        }) as typeof cancelAnimationFrame);
+    });
+
+    it('eases wheel zoom over multiple animation frames', () => {
+        const graphHost = document.getElementById('graph-host') as HTMLDivElement;
+        const graphHandle = renderExplorationGraph(graphHost, createGraph());
+        const svg = graphHost.querySelector('svg') as SVGSVGElement;
+        const viewport = svg.querySelector('g') as SVGGElement;
+
+        Object.defineProperty(svg, 'getBoundingClientRect', {
+            value: () => ({
+                left: 0,
+                top: 0,
+                width: 100,
+                height: 100,
+                right: 100,
+                bottom: 100,
+                x: 0,
+                y: 0,
+                toJSON: () => ({}),
+            }),
+            configurable: true,
+        });
+
+        const initialTransform = viewport.getAttribute('transform');
+        svg.dispatchEvent(new WheelEvent('wheel', {
+            deltaY: -120,
+            clientX: 50,
+            clientY: 50,
+            bubbles: true,
+            cancelable: true,
+        }));
+
+        expect(viewport.getAttribute('transform')).toBe(initialTransform);
+
+        flushAnimationFrame(0);
+        const firstFrameTransform = viewport.getAttribute('transform');
+        expect(firstFrameTransform).toBe(initialTransform);
+
+        flushAnimationFrame(90);
+        const midAnimationTransform = viewport.getAttribute('transform');
+        expect(midAnimationTransform).not.toBe(initialTransform);
+
+        flushAnimationFrame(220);
+        const finalTransform = viewport.getAttribute('transform');
+        expect(finalTransform).not.toBe(initialTransform);
+        expect(finalTransform).not.toBe(midAnimationTransform);
+
+        graphHandle.destroy();
+    });
+
+    it('accumulates consecutive wheel zoom ticks while easing is in progress', () => {
+        const graphHost = document.getElementById('graph-host') as HTMLDivElement;
+        const graphHandle = renderExplorationGraph(graphHost, createGraph());
+        const svg = graphHost.querySelector('svg') as SVGSVGElement;
+        const viewport = svg.querySelector('g') as SVGGElement;
+
+        Object.defineProperty(svg, 'getBoundingClientRect', {
+            value: () => ({
+                left: 0,
+                top: 0,
+                width: 100,
+                height: 100,
+                right: 100,
+                bottom: 100,
+                x: 0,
+                y: 0,
+                toJSON: () => ({}),
+            }),
+            configurable: true,
+        });
+
+        const initialScale = extractScale(viewport.getAttribute('transform'));
+
+        svg.dispatchEvent(new WheelEvent('wheel', {
+            deltaY: -120,
+            clientX: 50,
+            clientY: 50,
+            bubbles: true,
+            cancelable: true,
+        }));
+        flushAnimationFrame(0);
+
+        svg.dispatchEvent(new WheelEvent('wheel', {
+            deltaY: -120,
+            clientX: 50,
+            clientY: 50,
+            bubbles: true,
+            cancelable: true,
+        }));
+
+        flushAnimationFrame(220);
+        flushAnimationFrame(440);
+
+        const finalScale = extractScale(viewport.getAttribute('transform'));
+        expect(finalScale).toBeGreaterThan(initialScale * 1.08);
+
+        graphHandle.destroy();
+    });
+});

--- a/frontend/src/components/overlays/exploration-graph.ts
+++ b/frontend/src/components/overlays/exploration-graph.ts
@@ -9,6 +9,10 @@ type ExplorationGraphHandle = {
   destroy: () => void;
 };
 
+type ExplorationGraphOptions = {
+  onNodeActivated?: (node: MusicBrainzExplorationNode) => void;
+};
+
 type RenderNode = MusicBrainzExplorationNode & {
   x: number;
   y: number;
@@ -24,11 +28,14 @@ const WORLD_WIDTH = 1360;
 const WORLD_HEIGHT = 860;
 const CENTER_PADDING_X = 88;
 const CENTER_PADDING_Y = 82;
+const ZOOM_EASING_DURATION_MS = 180;
 
 const createSvgElement = <K extends keyof SVGElementTagNameMap>(tagName: K): SVGElementTagNameMap[K] =>
   document.createElementNS(SVG_NS, tagName);
 
 const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+const lerp = (from: number, to: number, progress: number): number => from + (to - from) * progress;
+const easeOutCubic = (progress: number): number => 1 - ((1 - progress) ** 3);
 
 const compactText = (value: string, maxLength: number): string => {
   const cleanValue = value.trim();
@@ -209,7 +216,11 @@ const relaxLayout = (nodes: RenderNode[], edges: MusicBrainzExplorationEdge[]): 
   }
 }
 
-export function renderExplorationGraph(container: HTMLElement, graph: MusicBrainzExplorationGraph): ExplorationGraphHandle {
+export function renderExplorationGraph(
+  container: HTMLElement,
+  graph: MusicBrainzExplorationGraph,
+  options: ExplorationGraphOptions = {},
+): ExplorationGraphHandle {
   const renderNodes: RenderNode[] = graph.nodes.map((node) => ({
     ...node,
     x: WORLD_WIDTH / 2,
@@ -286,19 +297,102 @@ export function renderExplorationGraph(container: HTMLElement, graph: MusicBrain
   let panOriginX = 0;
   let panOriginY = 0;
   let activeNode: RenderNode | null = null;
+  let dragMoved = false;
+  let suppressClickNodeID: string | null = null;
+  let zoomAnimationFrameId: number | null = null;
+  let zoomAnimationStartTime: number | null = null;
+  let zoomAnimationFromScale = scale;
+  let zoomAnimationFromTranslateX = translateX;
+  let zoomAnimationFromTranslateY = translateY;
+  let zoomAnimationTargetScale = scale;
+  let zoomAnimationTargetTranslateX = translateX;
+  let zoomAnimationTargetTranslateY = translateY;
 
   const updateViewport = () => {
     viewport.setAttribute('transform', `translate(${translateX} ${translateY}) scale(${scale})`);
   };
 
-  const toWorldPoint = (clientX: number, clientY: number) => {
+  const activeZoomTransform = () => {
+    if (zoomAnimationFrameId !== null) {
+      return {
+        scale: zoomAnimationTargetScale,
+        translateX: zoomAnimationTargetTranslateX,
+        translateY: zoomAnimationTargetTranslateY,
+      };
+    }
+
+    return {
+      scale,
+      translateX,
+      translateY,
+    };
+  };
+
+  const cancelZoomAnimation = () => {
+    if (zoomAnimationFrameId !== null && typeof window.cancelAnimationFrame === 'function') {
+      window.cancelAnimationFrame(zoomAnimationFrameId);
+    }
+
+    zoomAnimationFrameId = null;
+  zoomAnimationStartTime = null;
+    zoomAnimationFromScale = scale;
+    zoomAnimationFromTranslateX = translateX;
+    zoomAnimationFromTranslateY = translateY;
+    zoomAnimationTargetScale = scale;
+    zoomAnimationTargetTranslateX = translateX;
+    zoomAnimationTargetTranslateY = translateY;
+  };
+
+  const animateZoomTo = (nextScale: number, nextTranslateX: number, nextTranslateY: number) => {
+    cancelZoomAnimation();
+
+    if (nextScale === scale && nextTranslateX === translateX && nextTranslateY === translateY) {
+      return;
+    }
+
+    zoomAnimationFromScale = scale;
+    zoomAnimationFromTranslateX = translateX;
+    zoomAnimationFromTranslateY = translateY;
+    zoomAnimationTargetScale = nextScale;
+    zoomAnimationTargetTranslateX = nextTranslateX;
+    zoomAnimationTargetTranslateY = nextTranslateY;
+
+    const step = (timestamp: number) => {
+      if (zoomAnimationStartTime === null) {
+        zoomAnimationStartTime = timestamp;
+      }
+
+      const progress = clamp((timestamp - zoomAnimationStartTime) / ZOOM_EASING_DURATION_MS, 0, 1);
+      const easedProgress = easeOutCubic(progress);
+      scale = lerp(zoomAnimationFromScale, zoomAnimationTargetScale, easedProgress);
+      translateX = lerp(zoomAnimationFromTranslateX, zoomAnimationTargetTranslateX, easedProgress);
+      translateY = lerp(zoomAnimationFromTranslateY, zoomAnimationTargetTranslateY, easedProgress);
+      updateViewport();
+
+      if (progress < 1) {
+        zoomAnimationFrameId = window.requestAnimationFrame(step);
+        return;
+      }
+
+      zoomAnimationFrameId = null;
+      zoomAnimationStartTime = null;
+    };
+
+    zoomAnimationFrameId = window.requestAnimationFrame(step);
+  };
+
+  const toWorldPoint = (
+    clientX: number,
+    clientY: number,
+    transform: { scale: number; translateX: number; translateY: number } = { scale, translateX, translateY },
+  ) => {
     const rect = svg.getBoundingClientRect();
     const localX = ((clientX - rect.left) / rect.width) * WORLD_WIDTH;
     const localY = ((clientY - rect.top) / rect.height) * WORLD_HEIGHT;
 
     return {
-      x: (localX - translateX) / scale,
-      y: (localY - translateY) / scale,
+      x: (localX - transform.translateX) / transform.scale,
+      y: (localY - transform.translateY) / transform.scale,
     };
   };
 
@@ -317,6 +411,7 @@ export function renderExplorationGraph(container: HTMLElement, graph: MusicBrain
 
     const graphWidth = Math.max(1, bounds.maxX - bounds.minX);
     const graphHeight = Math.max(1, bounds.maxY - bounds.minY);
+    cancelZoomAnimation();
     scale = clampScale(Math.min(WORLD_WIDTH / (graphWidth + CENTER_PADDING_X), WORLD_HEIGHT / (graphHeight + CENTER_PADDING_Y), 1));
     translateX = (WORLD_WIDTH - graphWidth * scale) / 2 - bounds.minX * scale;
     translateY = (WORLD_HEIGHT - graphHeight * scale) / 2 - bounds.minY * scale;
@@ -373,6 +468,9 @@ export function renderExplorationGraph(container: HTMLElement, graph: MusicBrain
   const handlePointerMove = (event: PointerEvent) => {
     if (dragPointerId === event.pointerId && activeNode) {
       const point = toWorldPoint(event.clientX, event.clientY);
+      if (!dragMoved && (Math.abs(point.x - panStartX) > 1 || Math.abs(point.y - panStartY) > 1)) {
+        dragMoved = true;
+      }
       activeNode.x = clamp(dragStartX + (point.x - panStartX), activeNode.radius + 24, WORLD_WIDTH - activeNode.radius - 24);
       activeNode.y = clamp(dragStartY + (point.y - panStartY), activeNode.radius + 24, WORLD_HEIGHT - activeNode.radius - 24);
       activeNode.anchorX = activeNode.x;
@@ -394,8 +492,19 @@ export function renderExplorationGraph(container: HTMLElement, graph: MusicBrain
 
   const handlePointerUp = (event: PointerEvent) => {
     if (dragPointerId === event.pointerId) {
+      const completedNodeID = activeNode?.id || null;
+      const movedDuringDrag = dragMoved;
       dragPointerId = null;
       activeNode = null;
+      dragMoved = false;
+      if (movedDuringDrag && completedNodeID) {
+        suppressClickNodeID = completedNodeID;
+        window.setTimeout(() => {
+          if (suppressClickNodeID === completedNodeID) {
+            suppressClickNodeID = null;
+          }
+        }, 0);
+      }
     }
 
     if (panPointerId === event.pointerId) {
@@ -406,6 +515,7 @@ export function renderExplorationGraph(container: HTMLElement, graph: MusicBrain
 
   background.addEventListener('pointerdown', (event) => {
     event.preventDefault();
+    cancelZoomAnimation();
     panPointerId = event.pointerId;
     const rect = svg.getBoundingClientRect();
     panStartX = ((event.clientX - rect.left) / rect.width) * WORLD_WIDTH;
@@ -491,7 +601,21 @@ export function renderExplorationGraph(container: HTMLElement, graph: MusicBrain
     nodeElements.set(node.id, nodeGroup);
 
     nodeGroup.addEventListener('click', (event) => {
-      if (!(event.ctrlKey || event.metaKey) || !node.url) {
+      if (suppressClickNodeID === node.id) {
+        suppressClickNodeID = null;
+        return;
+      }
+
+      if (!(event.ctrlKey || event.metaKey)) {
+        if (options.onNodeActivated) {
+          event.preventDefault();
+          event.stopPropagation();
+          options.onNodeActivated(node);
+        }
+        return;
+      }
+
+      if (!node.url) {
         return;
       }
 
@@ -507,8 +631,10 @@ export function renderExplorationGraph(container: HTMLElement, graph: MusicBrain
 
       event.preventDefault();
       event.stopPropagation();
+      cancelZoomAnimation();
       activeNode = node;
       dragPointerId = event.pointerId;
+      dragMoved = false;
       dragStartX = node.x;
       dragStartY = node.y;
       const point = toWorldPoint(event.clientX, event.clientY);
@@ -524,19 +650,21 @@ export function renderExplorationGraph(container: HTMLElement, graph: MusicBrain
   const wheelHandler = (event: WheelEvent) => {
     event.preventDefault();
 
-    const beforeZoom = toWorldPoint(event.clientX, event.clientY);
-    const nextScale = clampScale(scale * (event.deltaY < 0 ? 1.08 : 0.92));
-    if (nextScale === scale) {
+    const zoomBase = activeZoomTransform();
+    const beforeZoom = toWorldPoint(event.clientX, event.clientY, zoomBase);
+    const nextScale = clampScale(zoomBase.scale * (event.deltaY < 0 ? 1.08 : 0.92));
+    if (nextScale === zoomBase.scale) {
       return;
     }
 
     const rect = svg.getBoundingClientRect();
     const localX = ((event.clientX - rect.left) / rect.width) * WORLD_WIDTH;
     const localY = ((event.clientY - rect.top) / rect.height) * WORLD_HEIGHT;
-    scale = nextScale;
-    translateX = localX - beforeZoom.x * scale;
-    translateY = localY - beforeZoom.y * scale;
-    updateViewport();
+    animateZoomTo(
+      nextScale,
+      localX - beforeZoom.x * nextScale,
+      localY - beforeZoom.y * nextScale,
+    );
   };
   svg.addEventListener('wheel', wheelHandler, { passive: false });
 
@@ -547,6 +675,7 @@ export function renderExplorationGraph(container: HTMLElement, graph: MusicBrain
 
   return {
     destroy: () => {
+      cancelZoomAnimation();
       svg.removeEventListener('pointermove', handlePointerMove);
       svg.removeEventListener('pointerup', handlePointerUp);
       svg.removeEventListener('pointercancel', handlePointerUp);

--- a/frontend/src/controllers/library-controller-events.test.ts
+++ b/frontend/src/controllers/library-controller-events.test.ts
@@ -216,6 +216,65 @@ describe('setupLibraryEventHandlers', () => {
         expect(deps.setSidebarExpanded).toHaveBeenCalledWith(false);
     });
 
+    it('preserves tagged album folder highlighting when toggling a search-tree folder', () => {
+        const { deps, libraryBrowser } = createDeps();
+        deps.options.getHighlightMusicBrainzTaggedAlbumFolders = () => true;
+        deps.getActiveSearchTreeRoot = vi.fn(() => ({
+            name: 'Library',
+            path: '',
+            musicBrainzTaggedAlbumDir: false,
+            folders: [{
+                name: 'Library',
+                path: 'Library',
+                musicBrainzTaggedAlbumDir: false,
+                folders: [{
+                    name: 'Artist One',
+                    path: 'Library/Artist One',
+                    musicBrainzTaggedAlbumDir: false,
+                    folders: [{
+                        name: 'Album One',
+                        path: 'Library/Artist One/Album One',
+                        musicBrainzTaggedAlbumDir: true,
+                        folders: [],
+                        trackEntries: [],
+                        textFileEntries: [],
+                        imageFileEntries: [],
+                    }],
+                    trackEntries: [],
+                    textFileEntries: [],
+                    imageFileEntries: [],
+                }],
+                trackEntries: [],
+                textFileEntries: [],
+                imageFileEntries: [],
+            }],
+            trackEntries: [],
+            textFileEntries: [],
+            imageFileEntries: [],
+        }));
+        setupLibraryEventHandlers(deps);
+
+        libraryBrowser.innerHTML = `
+            <li class="library-tree-node">
+                <button
+                    type="button"
+                    class="library-tree-folder"
+                    data-search-folder-path="Library/Artist One/Album One"
+                    data-search-folder-expandable="true"
+                >Album One</button>
+            </li>
+        `;
+
+        const button = libraryBrowser.querySelector('button') as HTMLButtonElement;
+        button.click();
+
+        expect(button.querySelector('.library-entry-icon.folder.musicbrainz-tagged-album')).not.toBeNull();
+
+        button.click();
+
+        expect(button.querySelector('.library-entry-icon.folder.musicbrainz-tagged-album')).not.toBeNull();
+    });
+
     it('shows the enumeration tooltip instead of navigating when descendants are not ready', async () => {
         const { deps, libraryBrowser } = createDeps();
         deps.options.isFolderImmediateDescendantsEnumerated = vi.fn(async () => false);

--- a/frontend/src/controllers/library-controller-events.ts
+++ b/frontend/src/controllers/library-controller-events.ts
@@ -256,11 +256,23 @@ export const setupLibraryEventHandlers = (deps: LibraryEventDeps): void => {
 
             if (expandedSearchFolders.has(searchFolderPath)) {
                 expandedSearchFolders.delete(searchFolderPath);
-                setSearchFolderButtonExpanded(button, folder.name, true, false);
+                setSearchFolderButtonExpanded(
+                    button,
+                    folder.name,
+                    true,
+                    false,
+                    folder.musicBrainzTaggedAlbumDir && options.getHighlightMusicBrainzTaggedAlbumFolders(),
+                );
                 collapseSearchTreeFolder(folderItem);
             } else {
                 expandedSearchFolders.add(searchFolderPath);
-                setSearchFolderButtonExpanded(button, folder.name, true, true);
+                setSearchFolderButtonExpanded(
+                    button,
+                    folder.name,
+                    true,
+                    true,
+                    folder.musicBrainzTaggedAlbumDir && options.getHighlightMusicBrainzTaggedAlbumFolders(),
+                );
                 expandSearchTreeFolder(folderItem, folder);
             }
             return;

--- a/frontend/src/controllers/library-controller.test.ts
+++ b/frontend/src/controllers/library-controller.test.ts
@@ -321,6 +321,52 @@ describe('createLibraryController', () => {
         expect(searchLibrary).toHaveBeenCalledWith('track 0', 0, 100);
     });
 
+    it('can expand all filtered folders for a programmatic library search', async () => {
+        const { controller } = mountLibraryController({
+            searchLibrary: async (query: string) => createSearchPage(query, [
+                {
+                    kind: 'folder',
+                    path: 'Library/Artist One',
+                    name: 'Artist One',
+                    folderPath: 'Library',
+                    relativePath: 'Library/Artist One',
+                    modifiedAtMs: 0,
+                },
+                {
+                    kind: 'folder',
+                    path: 'Library/Artist One/Album One',
+                    name: 'Album One',
+                    folderPath: 'Library/Artist One',
+                    relativePath: 'Library/Artist One/Album One',
+                    modifiedAtMs: 0,
+                },
+                {
+                    kind: 'track',
+                    path: '/music/library/artist-one/album-one/01 Intro.flac',
+                    name: '01 Intro.flac',
+                    folderPath: 'Library/Artist One/Album One',
+                    relativePath: 'Library/Artist One/Album One/01 Intro.flac',
+                    modifiedAtMs: 0,
+                },
+            ]),
+        });
+
+        controller.setLibraryRootName('Library');
+        controller.setSidebarOpen(true);
+        await flushPromises();
+
+        controller.startLibrarySearch('mbid-artist:test', { expandFilteredFolders: true });
+
+        await vi.advanceTimersByTimeAsync(220);
+        await flushPromises();
+
+        expect(controller.getLibrarySearchStateSnapshot().expandedFolderPaths).toEqual([
+            'Library',
+            'Library/Artist One',
+            'Library/Artist One/Album One',
+        ]);
+    });
+
     it('renders an expanded album grid and shrinks back when the search input is used', async () => {
         const { controller, libraryBrowser, librarySearch } = mountLibraryController();
 

--- a/frontend/src/controllers/library-controller.ts
+++ b/frontend/src/controllers/library-controller.ts
@@ -49,6 +49,10 @@ export type { LibraryControllerOptions } from './library-controller-types';
 
 export type LibraryController = ReturnType<typeof createLibraryController>;
 
+type ProgrammaticLibrarySearchOptions = {
+    expandFilteredFolders?: boolean;
+};
+
 type AlbumGridEntry = {
     folderPath: string;
     albumTitle: string;
@@ -102,6 +106,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
 
     let librarySearchRequestVersion = 0;
     let librarySearchDebounceHandle: number | undefined;
+    let expandFilteredFoldersOnNextSearchTree = false;
     let suppressNextLibrarySearchPasteInput = false;
     let activeSearchTreeRoot: SearchTreeNode | null = null;
     let pastedPathLookupCache: PastedPathLookupCache = createEmptyPastedPathLookupCache();
@@ -967,6 +972,7 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
 
     const cancelLibrarySearch = (): void => {
         librarySearchRequestVersion += 1;
+        expandFilteredFoldersOnNextSearchTree = false;
         controllerState.librarySearchPending = false;
         controllerState.activeSearchResult = null;
         controllerState.expandedSearchFolders.clear();
@@ -1175,6 +1181,19 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
         },
         setActiveSearchTreeRoot: (value) => {
             activeSearchTreeRoot = value;
+            if (value && expandFilteredFoldersOnNextSearchTree) {
+                const expandableFolderPaths = collectSearchTreeExpandableFolderPaths(value);
+                for (const folderPath of expandableFolderPaths) {
+                    if (folderPath === '') {
+                        continue;
+                    }
+
+                    controllerState.expandedSearchFolders.add(folderPath);
+                }
+            }
+            if (value) {
+                expandFilteredFoldersOnNextSearchTree = false;
+            }
         },
         getHoveredBrowserEntryKey: () => hoveredBrowserEntryKey,
         getLibraryRootName: () => controllerState.libraryRootName,
@@ -1704,10 +1723,24 @@ export const createLibraryController = (options: LibraryControllerOptions) => {
         return paths;
     };
 
-    const startLibrarySearch = (query: string): void => {
+    const startLibrarySearch = (query: string, options?: ProgrammaticLibrarySearchOptions): void => {
         const nextQuery = query.trim();
+        expandFilteredFoldersOnNextSearchTree = !!options?.expandFilteredFolders && nextQuery !== '';
         librarySearch.value = nextQuery;
         setLibrarySearchQuery(nextQuery);
+
+        if (expandFilteredFoldersOnNextSearchTree && activeSearchTreeRoot && normalizedLibrarySearchQuery() === nextQuery.toLowerCase()) {
+            const expandableFolderPaths = collectSearchTreeExpandableFolderPaths(activeSearchTreeRoot);
+            for (const folderPath of expandableFolderPaths) {
+                if (folderPath === '') {
+                    continue;
+                }
+
+                controllerState.expandedSearchFolders.add(folderPath);
+            }
+            expandFilteredFoldersOnNextSearchTree = false;
+            renderFolder('none');
+        }
     };
 
     const setSearchTreeSubtreeExpanded = (folderPath: string, expanded: boolean): void => {

--- a/frontend/src/main.test.ts
+++ b/frontend/src/main.test.ts
@@ -73,6 +73,7 @@ const testState = vi.hoisted(() => {
     const setEqualizerPosition = vi.fn();
     const setPlaybackOrderMode = vi.fn();
     const updatePlayOrderMenuState = vi.fn();
+    const openLibrarySearch = vi.fn();
 
     const createShell = () => {
         const cache = new Map<string, unknown>();
@@ -129,6 +130,7 @@ const testState = vi.hoisted(() => {
         normalizedSettings,
         playlistController,
         refreshAvailableAudioOutputDevices,
+        openLibrarySearch,
         refreshListenBrainzFeedbackForCurrentTrack,
         resetControllerScope: () => {
             controllerScope = null;
@@ -181,6 +183,7 @@ vi.mock('./app-runtime-setup', () => ({
         applyPlayerCardLayout: testState.applyPlayerCardLayout,
         defaultMusicBrainzServerUrl: 'https://musicbrainz.org',
         getStoredLayout: testState.getStoredLayout,
+        openLibrarySearch: testState.openLibrarySearch,
         visualizerController: {
             setEnabled: testState.setLissajousEnabled,
             setLissajousScale: testState.setLissajousScale,
@@ -306,6 +309,8 @@ vi.mock('../wailsjs/runtime/runtime', () => ({
     EventsOn: vi.fn(() => vi.fn()),
 }));
 
+import { setupExplorationButton } from './components/media-controls-exploration';
+
 describe('main entrypoint runtime scope', () => {
     beforeEach(() => {
         vi.resetModules();
@@ -379,5 +384,22 @@ describe('main entrypoint runtime scope', () => {
         expect(scope).not.toBeNull();
         expect(scope?.audioReinitializeBackend).toBeTypeOf('function');
         await expect(scope?.audioReinitializeBackend?.()).resolves.toEqual({ loaded: false });
+    });
+
+    it('routes the exploration search callback to the runtime openLibrarySearch helper', async () => {
+        await import('./main');
+
+        const call = vi.mocked(setupExplorationButton).mock.calls[0];
+        expect(call).toBeDefined();
+
+        const options = call?.[1] as { openLibrarySearch?: (query: string, searchOptions?: { expandFilteredFolders?: boolean }) => void } | undefined;
+        expect(options?.openLibrarySearch).toBeTypeOf('function');
+
+        options?.openLibrarySearch?.('mbid-artist:5e9450ca-77d5-4f64-a385-f453cfe98b24', { expandFilteredFolders: true });
+
+        expect(testState.openLibrarySearch).toHaveBeenCalledWith(
+            'mbid-artist:5e9450ca-77d5-4f64-a385-f453cfe98b24',
+            { expandFilteredFolders: true },
+        );
     });
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -96,6 +96,7 @@ renderAppShell(app);
 
 const state = createAppState();
 const runtimeControllerRefs = {} as ReturnType<typeof setupControllersFromScope>;
+let openExplorationLibrarySearch: ((query: string, options?: { expandFilteredFolders?: boolean }) => void) | null = null;
 
 setupExplorationButton(document, {
     getActiveTrack: () => (
@@ -103,6 +104,9 @@ setupExplorationButton(document, {
             ? state.tracks[state.currentTrackIndex]
             : undefined
     ),
+    openLibrarySearch: (query: string, options?: { expandFilteredFolders?: boolean }) => {
+        openExplorationLibrarySearch?.(query, options);
+    },
 });
 
 const musicBrainzEntityModalTransitionMs = UI_TIMINGS_MS.modalTransition;
@@ -433,6 +437,10 @@ Object.assign(runtimeScope, setupCoreServicesRuntime(Object.assign(Object.create
         runtimeScope.openTrackMetaMenu(clientX, clientY, includeCopyActions, actionScope, actionKind, actionPath);
     },
 })));
+
+openExplorationLibrarySearch = (query: string, options?: { expandFilteredFolders?: boolean }) => {
+    (runtimeScope as typeof runtimeScope & { openLibrarySearch?: (searchQuery: string, searchOptions?: { expandFilteredFolders?: boolean }) => void }).openLibrarySearch?.(query, options);
+};
 
 const {
     applyPlayerCardLayout,

--- a/frontend/src/utils/musicbrainz-entity-helpers.test.ts
+++ b/frontend/src/utils/musicbrainz-entity-helpers.test.ts
@@ -34,6 +34,7 @@ import {
     lookupMusicBrainzEntity,
     lookupMusicBrainzExploration,
     lookupMusicBrainzTrackMetadata,
+    musicBrainzMBIDSearchQuery,
     mbidForTrackEntity,
     renderMusicBrainzEntityContent,
     setMusicBrainzRequestLogServerResolver,
@@ -158,6 +159,11 @@ describe('musicbrainz entity helpers', () => {
         expect(mbidForTrackEntity({ ...track, mbIds: { ...track.mbIds, labelId: '' } }, 'label')).toBe('');
         expect(mbidForTrackEntity({ ...track, mbIds: {}, artistMbids: ['artist-two'] }, 'artist')).toBe('artist-two');
         expect(mbidForTrackEntity({ ...track, mbIds: {}, artistMbids: [] }, 'artist')).toBe('');
+        expect(musicBrainzMBIDSearchQuery('artist', ' Artist-ID ')).toBe('mbid-artist:artist-id');
+        expect(musicBrainzMBIDSearchQuery('release', 'Release-ID')).toBe('mbid-release:release-id');
+        expect(musicBrainzMBIDSearchQuery('recording', ' Recording-ID ')).toBe('mbid-recording:recording-id');
+        expect(musicBrainzMBIDSearchQuery('label', 'label-id')).toBe('');
+        expect(musicBrainzMBIDSearchQuery('artist', '   ')).toBe('');
         expect(faviconUrlForResource('https://example.com/page')).toBe('https://example.com/favicon.ico');
         expect(faviconUrlForResource('not a url')).toBeUndefined();
     });

--- a/frontend/src/utils/musicbrainz-entity-helpers.ts
+++ b/frontend/src/utils/musicbrainz-entity-helpers.ts
@@ -57,6 +57,25 @@ const emptyMusicBrainzExplorationGraph = (): MusicBrainzExplorationGraph => ({
     warnings: [],
 });
 
+export const musicBrainzMBIDSearchQuery = (entityType: string, mbid: string): string => {
+    const normalizedEntityType = entityType.trim().toLowerCase();
+    const normalizedMBID = mbid.trim().toLowerCase();
+    if (normalizedMBID === '') {
+        return '';
+    }
+
+    switch (normalizedEntityType) {
+        case 'artist':
+            return `mbid-artist:${normalizedMBID}`;
+        case 'release':
+            return `mbid-release:${normalizedMBID}`;
+        case 'recording':
+            return `mbid-recording:${normalizedMBID}`;
+        default:
+            return '';
+    }
+};
+
 export const lookupMusicBrainzTrackMetadata = async (recordingId: string, releaseId: string): Promise<MusicBrainzTrackMetadata> => {
     const cleanRecordingId = recordingId.trim();
     const cleanReleaseId = releaseId.trim();

--- a/musicbrainz_tag_db_query.go
+++ b/musicbrainz_tag_db_query.go
@@ -4,6 +4,22 @@ import (
 	"strings"
 )
 
+type musicBrainzEntityIDSearchQuery struct {
+	entityType string
+	mbid       string
+}
+
+func trimMusicBrainzSearchQueryValue(value string) string {
+	trimmedValue := strings.TrimSpace(value)
+	if len(trimmedValue) >= 2 {
+		if (trimmedValue[0] == '"' && trimmedValue[len(trimmedValue)-1] == '"') || (trimmedValue[0] == '\'' && trimmedValue[len(trimmedValue)-1] == '\'') {
+			trimmedValue = trimmedValue[1 : len(trimmedValue)-1]
+		}
+	}
+
+	return strings.TrimSpace(trimmedValue)
+}
+
 func parseMusicBrainzTagSearchQuery(query string) ([]string, bool) {
 	trimmedQuery := strings.TrimSpace(query)
 	if !strings.HasPrefix(strings.ToLower(trimmedQuery), "mbtag:") {
@@ -52,6 +68,141 @@ func parseMusicBrainzTagSearchQuery(query string) ([]string, bool) {
 
 	flush()
 	return normalizeMusicBrainzTagNames(tags), true
+}
+
+func parseMusicBrainzEntityIDSearchQuery(query string) (musicBrainzEntityIDSearchQuery, bool) {
+	trimmedQuery := strings.TrimSpace(query)
+	lowerQuery := strings.ToLower(trimmedQuery)
+
+	for _, candidate := range []struct {
+		prefix     string
+		entityType string
+	}{
+		{prefix: "mbid-artist:", entityType: "artist"},
+		{prefix: "mbid-release:", entityType: "release"},
+		{prefix: "mbid-recording:", entityType: "recording"},
+	} {
+		if !strings.HasPrefix(lowerQuery, candidate.prefix) {
+			continue
+		}
+
+		remainder := strings.TrimSpace(trimmedQuery[len(candidate.prefix):])
+		return musicBrainzEntityIDSearchQuery{
+			entityType: candidate.entityType,
+			mbid:       sanitizeMusicBrainzID(trimMusicBrainzSearchQueryValue(remainder)),
+		}, true
+	}
+
+	return musicBrainzEntityIDSearchQuery{}, false
+}
+
+func musicBrainzTagTrackRecordMatchesEntityMBID(record musicBrainzTagTrackRecord, query musicBrainzEntityIDSearchQuery) bool {
+	switch query.entityType {
+	case "artist":
+		for _, artistID := range record.ArtistIDs {
+			if artistID == query.mbid {
+				return true
+			}
+		}
+		return false
+	case "release":
+		return record.ReleaseID == query.mbid
+	case "recording":
+		return record.RecordingID == query.mbid
+	default:
+		return false
+	}
+}
+
+func (a *App) musicBrainzEntityIDMatchingPaths(query musicBrainzEntityIDSearchQuery) ([]string, []string, []string) {
+	if query.mbid == "" || !a.musicBrainzTagDatabaseEnabled() {
+		return nil, nil, nil
+	}
+
+	a.musicBrainzTagMu.Lock()
+	defer a.musicBrainzTagMu.Unlock()
+	a.ensureMusicBrainzTagDatabaseLoadedLocked()
+
+	folderPaths := make([]string, 0)
+	releaseFolderPaths := make([]string, 0)
+	trackPaths := make([]string, 0)
+	seenFolderPaths := make(map[string]struct{})
+	seenReleaseFolderPaths := make(map[string]struct{})
+	seenTrackPaths := make(map[string]struct{})
+	addFolderPath := func(folderPath string) {
+		cleanFolderPath := normalizeMusicBrainzTagFolderPath(folderPath)
+		if cleanFolderPath == "" {
+			return
+		}
+
+		folderKey := strings.ToLower(cleanFolderPath)
+		if _, exists := seenFolderPaths[folderKey]; exists {
+			return
+		}
+
+		seenFolderPaths[folderKey] = struct{}{}
+		folderPaths = append(folderPaths, cleanFolderPath)
+	}
+	addReleaseFolderPath := func(folderPath string) {
+		cleanFolderPath := normalizeMusicBrainzTagFolderPath(folderPath)
+		if cleanFolderPath == "" {
+			return
+		}
+
+		folderKey := strings.ToLower(cleanFolderPath)
+		if _, exists := seenReleaseFolderPaths[folderKey]; exists {
+			return
+		}
+
+		seenReleaseFolderPaths[folderKey] = struct{}{}
+		releaseFolderPaths = append(releaseFolderPaths, cleanFolderPath)
+	}
+	addTrackPath := func(trackPath string) {
+		cleanTrackPath := strings.TrimSpace(trackPath)
+		if cleanTrackPath == "" {
+			return
+		}
+
+		trackKey := strings.ToLower(cleanTrackPath)
+		if _, exists := seenTrackPaths[trackKey]; exists {
+			return
+		}
+
+		seenTrackPaths[trackKey] = struct{}{}
+		trackPaths = append(trackPaths, cleanTrackPath)
+	}
+
+	switch query.entityType {
+	case "release":
+		for folderPath := range a.musicBrainzTagReleaseFoldersByID[query.mbid] {
+			addReleaseFolderPath(folderPath)
+			addFolderPath(folderPath)
+		}
+	}
+
+	for path, record := range a.musicBrainzTagStore.Tracks {
+		if !musicBrainzTagTrackRecordMatchesEntityMBID(record, query) {
+			continue
+		}
+
+		addTrackPath(path)
+		switch query.entityType {
+		case "artist":
+			for _, folderPath := range record.ArtistFolderPaths {
+				addFolderPath(folderPath)
+			}
+			addReleaseFolderPath(record.ReleaseFolderPath)
+			addFolderPath(record.ReleaseFolderPath)
+		case "recording":
+			addReleaseFolderPath(record.ReleaseFolderPath)
+			addFolderPath(record.ReleaseFolderPath)
+		}
+	}
+
+	sortPathsCaseInsensitive(folderPaths)
+	sortPathsCaseInsensitive(releaseFolderPaths)
+	sortPathsCaseInsensitive(trackPaths)
+	return folderPaths, releaseFolderPaths, trackPaths
 }
 
 func (a *App) musicBrainzTagMatchingFolderPaths(tagNames []string) []string {
@@ -160,6 +311,82 @@ func (a *App) buildMusicBrainzTagSearchResultsLocked(tagNames []string) []Librar
 
 		appendEntry(folderBrowserEntry(cleanFolderPath, 0))
 		appendFolderEntries(cleanFolderPath)
+	}
+
+	sortBrowserEntriesByPath(entries)
+	return entries
+}
+
+func (a *App) buildMusicBrainzEntityIDSearchResultsLocked(query musicBrainzEntityIDSearchQuery) []LibraryBrowserEntry {
+	folderPaths, releaseFolderPaths, trackPaths := a.musicBrainzEntityIDMatchingPaths(query)
+	if len(folderPaths) == 0 && len(trackPaths) == 0 {
+		return []LibraryBrowserEntry{}
+	}
+
+	entries := make([]LibraryBrowserEntry, 0, len(folderPaths)+len(trackPaths))
+	seen := make(map[string]struct{}, len(folderPaths)+len(trackPaths))
+	appendEntry := func(entry LibraryBrowserEntry) {
+		entryKey := strings.ToLower(entry.Kind + ":" + entry.Path)
+		if _, exists := seen[entryKey]; exists {
+			return
+		}
+
+		seen[entryKey] = struct{}{}
+		entries = append(entries, entry)
+	}
+	releaseFolderPathSet := make(map[string]struct{}, len(releaseFolderPaths))
+	for _, folderPath := range releaseFolderPaths {
+		releaseFolderPathSet[strings.ToLower(folderPath)] = struct{}{}
+	}
+	appendFolderEntries := func(folderPath string, allowedChildFolderPaths map[string]struct{}) {
+		var folderEntries []LibraryBrowserEntry
+		indexState := a.libraryIndexState()
+		if a.isLibraryFolderIndexReadyLocked() {
+			folderEntries = indexState.folderEntriesByFolder[folderPath]
+		} else {
+			folderEntries = a.buildFolderEntriesFromMapsLocked(folderPath)
+		}
+
+		for _, entry := range folderEntries {
+			if entry.Kind == "folder" && allowedChildFolderPaths != nil {
+				if _, allowed := allowedChildFolderPaths[strings.ToLower(entry.Path)]; !allowed {
+					continue
+				}
+			}
+
+			appendEntry(entry)
+		}
+	}
+	appendTrackEntry := func(trackPath string) {
+		indexed, exists := a.libraryContentState().trackByPath[strings.TrimSpace(trackPath)]
+		if !exists {
+			return
+		}
+
+		appendEntry(browserEntryFromIndexedFile("track", indexed))
+	}
+
+	for _, folderPath := range folderPaths {
+		cleanFolderPath := normalizeMusicBrainzTagFolderPath(folderPath)
+		if cleanFolderPath == "" || !a.isMusicBrainzTagSearchFolderAvailableLocked(cleanFolderPath) {
+			continue
+		}
+
+		appendEntry(folderBrowserEntry(cleanFolderPath, 0))
+		switch query.entityType {
+		case "artist":
+			if _, isReleaseFolder := releaseFolderPathSet[strings.ToLower(cleanFolderPath)]; isReleaseFolder {
+				appendFolderEntries(cleanFolderPath, nil)
+			} else {
+				appendFolderEntries(cleanFolderPath, releaseFolderPathSet)
+			}
+		case "release":
+			appendFolderEntries(cleanFolderPath, nil)
+		}
+	}
+
+	for _, trackPath := range trackPaths {
+		appendTrackEntry(trackPath)
 	}
 
 	sortBrowserEntriesByPath(entries)


### PR DESCRIPTION
Introduce support for MusicBrainz MBID browser filtering, allowing for artist, release, and recording queries. Enhance the Connection Explorer with said functionality to facilitate smoother search interactions and maintain highlights for MusicBrainz tagged albums during folder toggling. Validate changes with CI.